### PR TITLE
integration: Get PXE working

### DIFF
--- a/integration/docker-compose.pxe.yml
+++ b/integration/docker-compose.pxe.yml
@@ -8,16 +8,17 @@ services:
     ports:
       - 8082:8082
     environment:
-      NODE_IP_SUBNET: 10.10.255.8
-      NODE_IP_NETMASK: 255.255.255.248
-      NODE_IP_RANGE_MIN: 10.10.255.9
-      NODE_IP_RANGE_MAX: 10.10.255.14
-      NODE_IP_ADDRESS: 10.10.255.9
+      NODE_IP_SUBNET: 10.10.10.0
+      NODE_IP_NETMASK: 255.255.255.0
+      NODE_IP_RANGE_MIN: 10.10.10.3
+      NODE_IP_RANGE_MAX: 10.10.10.253
+      NODE_IP_ADDRESS: 10.10.10.2
     volumes:
       - ./pxe/grubx64.efi:/var/lib/tftpboot/grubx64.efi:ro
       - ./pxe/dhcpd.conf.template:/etc/dhcp/dhcpd.conf.template:ro
     networks:
-      - opi
+      opi:
+        ipv4_address: 10.10.10.2
     healthcheck:
       test: curl --silent --fail http://localhost:8082 || exit 1
       interval: 6s
@@ -32,3 +33,8 @@ services:
             wait'
 networks:
   opi:
+    name: "opi"
+    ipam:
+      config:
+        - subnet: "10.10.10.0/24"
+          gateway: "10.10.10.1"

--- a/integration/docker-compose.spdk.yml
+++ b/integration/docker-compose.spdk.yml
@@ -35,4 +35,4 @@ services:
 
 networks:
   opi:
-
+    external: true

--- a/integration/docker-compose.telegraf.yml
+++ b/integration/docker-compose.telegraf.yml
@@ -43,4 +43,4 @@ volumes:
 
 networks:
   opi:
-
+    external: true

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -48,4 +48,4 @@ services:
 
 networks:
   opi:
-
+    external: true

--- a/integration/pxe/Dockerfile
+++ b/integration/pxe/Dockerfile
@@ -1,4 +1,4 @@
 FROM fedora:36
 
-RUN dnf install -y dhcp tftp-server tftp gettext syslinux net-tools
+RUN dnf install -y dhcp-server tftp-server tftp gettext syslinux net-tools
 


### PR DESCRIPTION
This changes the subnet definitions for the PXE setup, and also moves to
define the docker network in one docker compose file and then use it in
the other ones.

Signed-off-by: Kyle Mestery <mestery@mestery.com>