### PR TITLE
integration: Fix networking

### DIFF
--- a/integration/docker-compose.pxe.yml
+++ b/integration/docker-compose.pxe.yml
@@ -12,7 +12,7 @@ services:
       NODE_IP_NETMASK: 255.255.255.0
       NODE_IP_RANGE_MIN: 10.127.127.10
       NODE_IP_RANGE_MAX: 10.127.127.253
-      NODE_IP_ADDRESS: 10.127.127.2
+      NODE_IP_ADDRESS: 10.127.127.3
     volumes:
       - ./pxe/grubx64.efi:/var/lib/tftpboot/grubx64.efi:ro
       - ./pxe/dhcpd.conf.template:/etc/dhcp/dhcpd.conf.template:ro

--- a/integration/docker-compose.pxe.yml
+++ b/integration/docker-compose.pxe.yml
@@ -8,17 +8,17 @@ services:
     ports:
       - 8082:8082
     environment:
-      NODE_IP_SUBNET: 10.10.10.0
+      NODE_IP_SUBNET: 10.127.127.0
       NODE_IP_NETMASK: 255.255.255.0
-      NODE_IP_RANGE_MIN: 10.10.10.3
-      NODE_IP_RANGE_MAX: 10.10.10.253
-      NODE_IP_ADDRESS: 10.10.10.2
+      NODE_IP_RANGE_MIN: 10.127.127.10
+      NODE_IP_RANGE_MAX: 10.127.127.253
+      NODE_IP_ADDRESS: 10.127.127.2
     volumes:
       - ./pxe/grubx64.efi:/var/lib/tftpboot/grubx64.efi:ro
       - ./pxe/dhcpd.conf.template:/etc/dhcp/dhcpd.conf.template:ro
     networks:
       opi:
-        ipv4_address: 10.10.10.2
+        ipv4_address: 10.127.127.3
     healthcheck:
       test: curl --silent --fail http://localhost:8082 || exit 1
       interval: 6s
@@ -33,8 +33,8 @@ services:
             wait'
 networks:
   opi:
-    name: "opi"
+    name: opi
     ipam:
       config:
-        - subnet: "10.10.10.0/24"
-          gateway: "10.10.10.1"
+        - subnet: "10.127.127.0/24"
+          gateway: "10.127.127.1"

--- a/integration/docker-compose.telegraf.yml
+++ b/integration/docker-compose.telegraf.yml
@@ -43,4 +43,5 @@ volumes:
 
 networks:
   opi:
+    name: opi
     external: true

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: host-cpu
     ports:
-      - 22:22
+      - 8022:22
     command: /usr/sbin/sshd -D -e
 
   host-bmc:
@@ -35,7 +35,7 @@ services:
     build:
       context: xpu-cpu
     ports:
-      - 22:22
+      - 9022:22
     command: /usr/sbin/sshd -D -e
 
   xpu-bmc:


### PR DESCRIPTION
This commit fixes the integration docker compose setup to get the
networking correct. A few items were address:

* Change subnet to 10.127.127.0/24
* Use separate host port mappings for the multiple ssh servers
* Add a name to the opi network

With this change, things come up smoothly:

```
vagrant@bullseye:/git/opi-poc/integration$ docker compose -f docker-compose.yml -f docker-compose.telegraf.yml -f docker-compose.pxe.yml up -d
[+] Running 8/8
 ⠿ Network opi                       Created                                                                                                                                                                        0.0s
 ⠿ Container integration-host-cpu-1  Started                                                                                                                                                                        1.0s
 ⠿ Container integration-influxdb-1  Started                                                                                                                                                                        1.0s
 ⠿ Container integration-pxe-1       Started                                                                                                                                                                        0.9s
 ⠿ Container integration-xpu-cpu-1   Started                                                                                                                                                                        1.1s
 ⠿ Container integration-host-bmc-1  Started                                                                                                                                                                        1.2s
 ⠿ Container integration-xpu-bmc-1   Started                                                                                                                                                                        0.9s
 ⠿ Container integration-telegraf-1  Started                                                                                                                                                                        1.4s
vagrant@bullseye:/git/opi-poc/integration$
```

Signed-off-by: Kyle Mestery <mestery@mestery.com>