### PR TITLE
integration: Use script for examples

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -12,6 +12,21 @@
 
 ## Test
 
+To manually check the run, execute the following:
+
+<!-- markdownlint-disable -->
+* Check Prometheus at <http://0.0.0.0:9090>
+* Check Platform/Host BMC redfish server <http://0.0.0.0:8001/redfish/v1>
+* Check NIC/DPU/IPU BMC redfish server <http://0.0.0.0:8002/redfish/v1>
+* Check PXE server <http://0.0.0.0:8082/var/lib/tftpboot>
+* Log into Host CPU: `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2210 host@127.0.0.1`
+* Log into Host BMC: `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2208 bmc@127.0.0.1`
+* Log into  xPU CPU: `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2207 xpu@127.0.0.1`
+* Log into  xPU BMC: `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2209 bmc@127.0.0.1`
+<!-- markdownlint-restore -->
+
+You can also run the CI tests and log collection as follows:
+
 ```bash
 ./scripts/integration.sh run-tests
 ./scripts/integration.sh logs

--- a/integration/README.md
+++ b/integration/README.md
@@ -6,29 +6,19 @@
 
 ## Start
 
-<!-- markdownlint-disable -->
 ```bash
-docker-compose -f docker-compose.yml -f docker-compose.xpu.yml -f docker-compose.otel.yml -f docker-compose.spdk.yml -f docker-compose.pxe.yml up
+./scripts/integration.sh build-start
 ```
-<!-- markdownlint-restore -->
 
 ## Test
 
-<!-- markdownlint-disable -->
-* Check Prometheus at <http://0.0.0.0:9090>
-* Check Platform/Host BMC redfish server <http://0.0.0.0:8001/redfish/v1>
-* Check NIC/DPU/IPU BMC redfish server <http://0.0.0.0:8002/redfish/v1>
-* Check PXE server <http://0.0.0.0:8082/var/lib/tftpboot>
-* Log into Host CPU: `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2210 host@127.0.0.1`
-* Log into Host BMC: `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2208 bmc@127.0.0.1`
-* Log into  xPU CPU: `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2207 xpu@127.0.0.1`
-* Log into  xPU BMC: `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2209 bmc@127.0.0.1`
-<!-- markdownlint-restore -->
+```bash
+./scripts/integration.sh run-tests
+./scripts/integration.sh logs
+```
 
 ## Stop
 
-<!-- markdownlint-disable -->
 ```bash
-docker-compose -f docker-compose.yml -f docker-compose.xpu.yml -f docker-compose.otel.yml -f docker-compose.spdk.yml -f docker-compose.pxe.yml down --remove-orphans
+./scripts/integration.sh stop
 ```
-<!-- markdownlint-restore -->


### PR DESCRIPTION
This modifies the README.md to reflect the fact we can use the actual
integration tests run in the CI for developer usage as well.

Further, it modifies the integration.sh script to handle various version
of `docker compose`, including how it is installed.

Signed-off-by: Kyle Mestery <mestery@mestery.com>