### PR TITLE
integration: Really separate build and start

### DIFF
--- a/.github/workflows/poc-integration.yml
+++ b/.github/workflows/poc-integration.yml
@@ -42,8 +42,12 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Build & Start containers
-      run: ./scripts/integration.sh build-start
+    - name: Build containers
+      run: ./scripts/integration.sh build
+      working-directory: integration
+
+    - name: Start containers
+      run: ./scripts/integration.sh start
       working-directory: integration
 
     - name: Run Integration Tests

--- a/integration/README.md
+++ b/integration/README.md
@@ -7,7 +7,8 @@
 ## Start
 
 ```bash
-./scripts/integration.sh build-start
+./scripts/integration.sh build
+./scripts/integration.sh start
 ```
 
 ## Test

--- a/integration/scripts/integration.sh
+++ b/integration/scripts/integration.sh
@@ -5,7 +5,7 @@
 set -euxo pipefail
 
 INT_BUILD=build
-INT_BUILD_START=build-start
+INT_START=start
 INT_RUN_TESTS=run-tests
 INT_LOGS=logs
 INT_STOP=stop
@@ -20,7 +20,7 @@ fi
 
 usage() {
     echo ""
-    echo "Usage: integration.sh [${INT_BUILD} | ${INT_BUILD_START} | ${INT_RUN_TESTS} | ${INT_LOGS} | ${INT_STOP}]"
+    echo "Usage: integration.sh [${INT_BUILD} | ${INT_START} | ${INT_RUN_TESTS} | ${INT_LOGS} | ${INT_STOP}]"
     echo ""
 }
 
@@ -77,9 +77,8 @@ fi
 if [ "$1" == "${INT_BUILD}" ]
 then
     build_containers
-elif [ "$1" == "${INT_BUILD_START}" ]
+elif [ "$1" == "${INT_START}" ]
 then
-    build_containers
     start_containers
 elif [ "$1" == "${INT_RUN_TESTS}" ]
 then


### PR DESCRIPTION
Commit d2c2f91 made a separate build argument to the integration script,
but left build-start. This commit makes the split between build and
start much more clear by decoupling them completely and requiring each
to be called to run the integration tests.

Signed-off-by: Kyle Mestery <mestery@mestery.com>