### PR TITLE
integration: remove inspect command

### DIFF
--- a/integration/scripts/integration.sh
+++ b/integration/scripts/integration.sh
@@ -64,7 +64,6 @@ acquire_logs() {
     bash -c "${DC} -f docker-compose.yml -f docker-compose.xpu.yml -f docker-compose.otel.yml -f docker-compose.spdk.yml -f docker-compose.pxe.yml logs" || true
     netstat -an || true
     ifconfig -a || true
-    docker inspect bash -c "${DC} compose -f docker-compose.yml -f docker-compose.xpu.yml -f docker-compose.otel.yml -f docker-compose.spdk.yml -f docker-compose.pxe.yml ps -aq" || true
 }
 
 stop_containers() {


### PR DESCRIPTION
it was added to find the DHCP issue and doesn't provide a lot of value
and it crashes now with new DC syntax changes, so removing it.

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
