### PR TITLE
spdk: Use multi-stage Docker build

### DIFF
--- a/integration/docker-compose.spdk.yml
+++ b/integration/docker-compose.spdk.yml
@@ -19,8 +19,8 @@ services:
       sh -x -c 'sync; echo 1 > /proc/sys/vm/drop_caches  && \
             echo 1024 > /proc/sys/vm/nr_hugepages && \
             grep "" /sys/kernel/mm/hugepages/hugepages-*/nr_hugepages && \
-            /root/spdk/build/bin/spdk_tgt -m 0x1 -s 512 --no-pci 2>&1 & \
-            echo wait 5s... && sleep 5s && cd /root/spdk/scripts && \
+            /usr/local/bin/spdk_tgt -m 0x1 -s 512 --no-pci 2>&1 & \
+            echo wait 5s... && sleep 5s && cd /usr/libexec/spdk/scripts && \
             for i in `seq 1 10`; do ./rpc.py spdk_get_version && break || sleep 1; done  && \
             ./rpc.py bdev_malloc_create -b Malloc0 64 512 && \
             ./rpc.py bdev_malloc_create -b Malloc1 64 512 && \

--- a/integration/docker-compose.xpu.yml
+++ b/integration/docker-compose.xpu.yml
@@ -67,8 +67,8 @@ services:
       sh -x -c 'sync; echo 1 > /proc/sys/vm/drop_caches  && \
             echo 1024 > /proc/sys/vm/nr_hugepages && \
             grep "" /sys/kernel/mm/hugepages/hugepages-*/nr_hugepages && \
-            /root/spdk/build/bin/spdk_tgt -m 0x1 -s 512 --no-pci 2>&1 & \
-            echo wait 5s... && sleep 5s && cd /root/spdk/scripts && \
+            /usr/local/bin/spdk_tgt -m 0x1 -s 512 --no-pci 2>&1 & \
+            echo wait 5s... && sleep 5s && cd /usr/libexec/spdk/scripts && \
             for i in `seq 1 10`; do ./rpc.py spdk_get_version && break || sleep 1; done  && \
             ./rpc.py bdev_malloc_create -b Malloc0 64 512 && \
             ./rpc.py bdev_malloc_create -b Malloc1 64 512 && \

--- a/integration/scripts/integration.sh
+++ b/integration/scripts/integration.sh
@@ -75,10 +75,10 @@ run_integration_tests() {
     bash -c "${DC} exec -T pxe curl --fail http://10.127.127.3:8082/var/lib/tftpboot/"
     bash -c "${DC} exec -T pxe tftp 10.127.127.3 -v -c get grubx64.efi"
     bash -c "${DC} exec -T sztp ./run-sztpd-test.sh"
-    bash -c "${DC} exec -T spdk-target /root/spdk/build/examples/identify -r 'traddr:10.127.127.4 trtype:TCP adrfam:IPv4 trsvcid:4420'"
-    bash -c "${DC} exec -T xpu-spdk /root/spdk/build/examples/identify    -r 'traddr:10.127.127.4 trtype:TCP adrfam:IPv4 trsvcid:4420'"
-    bash -c "${DC} exec -T spdk-target /root/spdk/build/examples/perf     -r 'traddr:10.127.127.4 trtype:TCP adrfam:IPv4 trsvcid:4420' -c 0x1 -q 1 -o 4096 -w randread -t 10"
-    bash -c "${DC} exec -T xpu-spdk /root/spdk/build/examples/perf        -r 'traddr:10.127.127.4 trtype:TCP adrfam:IPv4 trsvcid:4420' -c 0x1 -q 1 -o 4096 -w randread -t 10"
+    bash -c "${DC} exec -T spdk-target /usr/local/bin/identify -r 'traddr:10.127.127.4 trtype:TCP adrfam:IPv4 trsvcid:4420'"
+    bash -c "${DC} exec -T xpu-spdk /usr/local/bin/identify    -r 'traddr:10.127.127.4 trtype:TCP adrfam:IPv4 trsvcid:4420'"
+    bash -c "${DC} exec -T spdk-target /usr/local/bin/perf     -r 'traddr:10.127.127.4 trtype:TCP adrfam:IPv4 trsvcid:4420' -c 0x1 -q 1 -o 4096 -w randread -t 10"
+    bash -c "${DC} exec -T xpu-spdk /usr/local/bin/perf         -r 'traddr:10.127.127.4 trtype:TCP adrfam:IPv4 trsvcid:4420' -c 0x1 -q 1 -o 4096 -w randread -t 10"
 }
 
 acquire_logs() {

--- a/integration/spdk/Dockerfile
+++ b/integration/spdk/Dockerfile
@@ -1,17 +1,23 @@
-FROM fedora:36
+FROM fedora:36 as build
 
 ARG TAG=v22.05
 ARG ARCH=native
 
 WORKDIR /root
-RUN dnf install -y git diffutils procps-ng && dnf clean all
+RUN dnf install -y git rpm-build diffutils procps-ng && dnf clean all
 
 # hadolint ignore=DL3003
 RUN git clone https://github.com/spdk/spdk --branch ${TAG} --depth 1 && \
     cd spdk && git submodule update --init --depth 1 && scripts/pkgdep.sh --rdma
 
 # hadolint ignore=DL3003
-RUN cd spdk && \
-    ./configure --disable-tests --without-vhost --without-virtio \
-                --with-rdma --target-arch=${ARCH} && \
-    make
+RUN cd spdk && ./rpmbuild/rpm.sh --without-uring --without-crypto \
+    --without-fio --with-raid5 --with-vhost --without-pmdk --without-rbd \
+    --with-rdma --with-shared --with-iscsi-initiator --without-vtune --without-isal
+
+FROM fedora:36
+
+WORKDIR /root
+RUN mkdir -p /root/rpmbuild
+COPY --from=build /root/rpmbuild/ /root/rpmbuild/
+RUN dnf install -y /root/rpmbuild/rpm/x86_64/*.rpm && dnf clean all


### PR DESCRIPTION
Move to a multi-stage build for the SPDK container to "contain" it's
size. You can see the shrinking that happens once we do this below:

```
vagrant@bullseye:~$ docker images|grep spdk
integration_xpu-spdk                          latest         c3628be1417d   6 minutes ago    219MB
integration_spdk-target                       latest         c3628be1417d   6 minutes ago    219MB
integration_ipu-spdk                          latest         71e23aabe2f3   12 days ago      1.24GB
integration_spdk                              latest         71e23aabe2f3   12 days ago      1.24GB
```

Closes #115

Signed-off-by: Kyle Mestery <mestery@mestery.com>