### PR TITLE
tests: Add Kong tests

### DIFF
--- a/integration/docker-compose.xpu.yml
+++ b/integration/docker-compose.xpu.yml
@@ -168,8 +168,8 @@ services:
       <<: *kong-env
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr
-      KONG_PROXY_LISTEN: "${KONG_PROXY_LISTEN:-0.0.0.0:8010}"
-      KONG_ADMIN_LISTEN: "${KONG_ADMIN_LISTEN:-0.0.0.0:8011}"
+      KONG_PROXY_LISTEN: "0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport backlog=16384"
+      KONG_ADMIN_LISTEN: "0.0.0.0:8001 reuseport backlog=16384, 0.0.0.0:8444 http2 ssl reuseport backlog=16384"
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
       KONG_PREFIX: ${KONG_PREFIX:-/var/run/kong}

--- a/integration/scripts/integration.sh
+++ b/integration/scripts/integration.sh
@@ -77,6 +77,11 @@ run_integration_tests() {
     bash -c "${DC} exec -T xpu-spdk /usr/local/bin/identify    -r 'traddr:10.129.129.4 trtype:TCP adrfam:IPv4 trsvcid:4420'"
     bash -c "${DC} exec -T spdk-target /usr/local/bin/perf     -r 'traddr:10.129.129.4 trtype:TCP adrfam:IPv4 trsvcid:4420' -c 0x1 -q 1 -o 4096 -w randread -t 10"
     bash -c "${DC} exec -T xpu-spdk /usr/local/bin/perf         -r 'traddr:10.129.129.4 trtype:TCP adrfam:IPv4 trsvcid:4420' -c 0x1 -q 1 -o 4096 -w randread -t 10"
+    #
+    # Kong tests
+    #
+    bash -c "${DC} exec -T kong curl -i http://localhost:8001/"
+    bash -c "${DC} exec -T kong curl -i --insecure https://localhost:8444/"
 }
 
 acquire_logs() {

--- a/integration/scripts/integration.sh
+++ b/integration/scripts/integration.sh
@@ -80,8 +80,8 @@ run_integration_tests() {
     #
     # Kong tests
     #
-    bash -c "${DC} exec -T kong curl -i http://localhost:8001/"
-    bash -c "${DC} exec -T kong curl -i --insecure https://localhost:8444/"
+    bash -c "${DC} exec -T xpu-cpu-ssh curl -i http://localhost:8001/"
+    bash -c "${DC} exec -T xpu-cpu-ssh curl -i --insecure https://localhost:8444/"
 }
 
 acquire_logs() {


### PR DESCRIPTION
This updates the Kong configuation to listen on https as well as http
ports. It adds some simple API tests to verify the API endpoints are up
and running as well.

Closes #120

Signed-off-by: Kyle Mestery <mestery@mestery.com>