### PR TITLE
SPDK: Build without AVX instructions

### DIFF
--- a/storage/Dockerfile
+++ b/storage/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:36 as build
 
 ARG TAG=v22.05
-ARG ARCH=native
+ARG ARCH=x86_64
 
 WORKDIR /root
 RUN dnf install -y git rpm-build diffutils procps-ng && dnf clean all


### PR DESCRIPTION
We can't use `native` as the ARCH for SPDK builds because the Azure
Runners which GitHub Actions uses container CPUs with those
instructions. Instead, force the ARCH to `x86_64` so the build wil
disable those instructions [1].

Closes #159 

[1] https://github.com/spdk/spdk/blob/master/mk/spdk.common.mk#L73-L78

Signed-off-by: Kyle Mestery <mestery@mestery.com>