### PR TITLE
spdk: Use native arch and skip AVX

### DIFF
--- a/.github/workflows/poc-storage.yml
+++ b/.github/workflows/poc-storage.yml
@@ -85,6 +85,7 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        build-args: OPI_SPDK_CFLAGS=-mno-avx512f
 
     # Sign the resulting Docker image digest except on PRs.
     # This will only write to the public Rekor transparency log when the Docker

--- a/storage/Dockerfile
+++ b/storage/Dockerfile
@@ -2,6 +2,7 @@ FROM fedora:36 as build
 
 ARG TAG=v22.05
 ARG ARCH=native
+ARG OPI_SPDK_CFLAGS
 
 WORKDIR /root
 RUN dnf install -y git rpm-build diffutils procps-ng && dnf clean all
@@ -11,7 +12,7 @@ RUN git clone https://github.com/spdk/spdk --branch ${TAG} --depth 1 && \
     cd spdk && git submodule update --init --depth 1 && scripts/pkgdep.sh --rdma
 
 # hadolint ignore=DL3003
-RUN cd spdk && CFLAGS=-mno-avx512f ./rpmbuild/rpm.sh --without-uring --without-crypto \
+RUN cd spdk && CFLAGS="${OPI_SPDK_CFLAGS}" ./rpmbuild/rpm.sh --without-uring --without-crypto \
     --without-fio --with-raid5 --with-vhost --without-pmdk --without-rbd \
     --with-rdma --with-shared --with-iscsi-initiator --without-vtune --without-isal
 

--- a/storage/Dockerfile
+++ b/storage/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:36 as build
 
 ARG TAG=v22.05
-ARG ARCH=x86_64
+ARG ARCH=native
 
 WORKDIR /root
 RUN dnf install -y git rpm-build diffutils procps-ng && dnf clean all
@@ -11,7 +11,7 @@ RUN git clone https://github.com/spdk/spdk --branch ${TAG} --depth 1 && \
     cd spdk && git submodule update --init --depth 1 && scripts/pkgdep.sh --rdma
 
 # hadolint ignore=DL3003
-RUN cd spdk && ./rpmbuild/rpm.sh --without-uring --without-crypto \
+RUN cd spdk && CFLAGS=-mno-avx512f ./rpmbuild/rpm.sh --without-uring --without-crypto \
     --without-fio --with-raid5 --with-vhost --without-pmdk --without-rbd \
     --with-rdma --with-shared --with-iscsi-initiator --without-vtune --without-isal
 

--- a/storage/Dockerfile
+++ b/storage/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:36 as build
 
 ARG TAG=v22.05
 ARG ARCH=native
-ARG OPI_SPDK_CFLAGS
+ARG OPI_SPDK_CFLAGS=""
 
 WORKDIR /root
 RUN dnf install -y git rpm-build diffutils procps-ng && dnf clean all


### PR DESCRIPTION
This moves back to native arch for the SPDK container, but removes AVX
using CFLAGS instead.

Note that this may not work on ARM, and we may need to conditionally
remove AVX only for x86_64 targets.

Related #160

Signed-off-by: Kyle Mestery <mestery@mestery.com>