### PR TITLE
build: Push storage container on PRs

### DIFF
--- a/.github/workflows/poc-storage.yml
+++ b/.github/workflows/poc-storage.yml
@@ -36,20 +36,12 @@ jobs:
       run: |
         make -C storage shellcheck
 
-  docker-publish:
+  docker-build:
     needs: storage-shellcheck
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-
-    # Install the cosign tool except on PR
-    # https://github.com/sigstore/cosign-installer
-    - name: Install cosign
-      if: github.event_name != 'pull_request'
-      uses: sigstore/cosign-installer@48866aa521d8bf870604709cd43ec2f602d03ff2
-      with:
-        cosign-release: 'v1.9.0'
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
@@ -61,11 +53,10 @@ jobs:
     # Login against a Docker registry except on PR
     # https://github.com/docker/login-action
     - name: Log into registry ${{ env.REGISTRY }}
-      if: github.event_name != 'pull_request'
       uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
       with:
         registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     # Extract metadata (tags, labels) for Docker
@@ -74,47 +65,41 @@ jobs:
       id: meta
       uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a
       with:
+        sep-tags: ","
+        sep-labels: ","
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        # Docker tags based on the following events/attributes
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha
 
-    # Build and push Docker image with Buildx (don't push on PR)
+    # Build and push Docker image with Buildx
     # https://github.com/docker/build-push-action
-    - name: Build and push Docker image
-      id: build-and-push
+    - name: Build Docker image
+      id: build
       uses: docker/build-push-action@1cb9d22b932e4832bb29793b7777ec860fc1cde0
       with:
         context: storage
-        push: ${{ github.event_name != 'pull_request' }}
+        push: false
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        outputs: type=docker,dest=/tmp/myimage.tar
 
-    # Sign the resulting Docker image digest except on PRs.
-    # This will only write to the public Rekor transparency log when the Docker
-    # repository is public to avoid leaking data.  If you would like to publish
-    # transparency data even for private images, pass --force to cosign below.
-    # https://github.com/sigstore/cosign
-    - name: Sign the published Docker image
-      if: ${{ github.event_name != 'pull_request' }}
-      env:
-        COSIGN_EXPERIMENTAL: "true"
-      # This step uses the identity token to provision an ephemeral certificate
-      # against the sigstore community Fulcio instance.
-      run: cosign sign ${{ steps.meta.outputs.tags }}@${{ steps.build-and-push.outputs.digest }}
+    - name: Load docker image locally
+      run: docker image load < /tmp/myimage.tar
+      working-directory: storage
 
-  ut:
-    needs: docker-publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+    - name: List docker images
+      run: docker image ls
+      working-directory: storage
 
     - name: Start containers
-      run: ./scripts/poc.sh start
+      run: SPDK_TAG=sha-$(git rev-parse --short ${{ github.sha }}) ./scripts/poc.sh start
       working-directory: storage
 
     - name: Run Tests
@@ -130,3 +115,25 @@ jobs:
       if: always()
       run: ./scripts/poc.sh stop
       working-directory: storage
+
+    - name: Upload build artifact
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.os }}-${{ steps.system.outputs.arch }}
+        path: /tmp/myimage.tar
+        retention-days: 1
+
+    # Build and push Docker image with Buildx
+    # https://github.com/docker/build-push-action
+    # NOTE: The second time we run this, the iamge should already be
+    # built, and we're just doing the push to ghcr.io
+    - name: Push Docker image
+      id: push-to-ghcr
+      uses: docker/build-push-action@1cb9d22b932e4832bb29793b7777ec860fc1cde0
+      if: github.event_name != 'pull_request'
+      with:
+        context: storage
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/storage/docker-compose.yml
+++ b/storage/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
 
   spdk:
-    image: ghcr.io/opiproject/opi-spdk:main
+    image: "ghcr.io/opiproject/opi-spdk:${SPDK_TAG-main}"
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This commit adds the ability to push container images to GHCR during the
storage container build while running on pull requests. Useful for
testing container images resulting from PRs.

Closes #161
Closes #162

Signed-off-by: Kyle Mestery <mestery@mestery.com>