### PR TITLE
telegraf: add another agent to host

### DIFF
--- a/integration/docker-compose.host.yml
+++ b/integration/docker-compose.host.yml
@@ -40,6 +40,13 @@ services:
       start_period: 20s
       timeout: 10s
 
+  host-telegraf:
+    build:
+      context: host-cpu
+      dockerfile: Dockerfile.telegraf
+    network_mode: service:host-cpu-ssh
+    privileged: true
+
   host-bmc-ssh:
     image: linuxserver/openssh-server:8.8_p1-r1-ls84
     hostname: host-bmc

--- a/integration/host-cpu/Dockerfile.telegraf
+++ b/integration/host-cpu/Dockerfile.telegraf
@@ -1,0 +1,2 @@
+FROM telegraf:1.22
+COPY telegraf-redfish.conf /etc/telegraf/telegraf.conf

--- a/integration/host-cpu/telegraf-redfish.conf
+++ b/integration/host-cpu/telegraf-redfish.conf
@@ -1,0 +1,24 @@
+[[inputs.redfish]]
+  address = "http://host-bmc-ssh:8000"
+  username = "root"
+  password = "password123456"
+  computer_system_id="437XR1138R2"
+
+[[inputs.cpu]]
+  percpu = true
+  totalcpu = true
+  collect_cpu_time = false
+  report_active = false
+
+[[inputs.mem]]
+  # no configuration
+
+[[inputs.net]]
+  ignore_protocol_stats = false
+
+[[outputs.file]]
+  files = ["stdout"]
+  data_format = "influx"
+
+[[outputs.opentelemetry]]
+  service_address = "otel-gw-collector:4317"


### PR DESCRIPTION
like agent on xPU it is another agent on host
both agents send data to otel collector gw

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
