### PR TITLE
Fixes for Red Hat environments

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -18,18 +18,16 @@ docker-compose version 1.29.2, build unknown
 ### Prereqs - Red Hat
 
 docker-compose does work on Red Hat OSes starting with podman 3.x.
-For example, on Fedora:
+For example:
 
 ```bash
-sudo dnf install -y podman podman-docker docker-compose
+sudo dnf install -y podman podman-docker
 sudo systemctl enable podman.socket --now
-# TODO volume mounts need adjustments for SELinux, disable for now
-sudo setenforce 0
 ```
 
 ### Prereqs - PIP
 
-one can also install latest docker-compose via PIP
+One can install latest docker-compose via PIP
 
 ```bash
 sudo python3 -m pip install --upgrade docker-compose

--- a/integration/docker-compose.otel.yml
+++ b/integration/docker-compose.otel.yml
@@ -26,7 +26,7 @@ services:
   prometheus:
     image: prom/prometheus:v2.36.2
     volumes:
-      - ./otel/prometheus.yaml:/etc/prometheus/prometheus.yml
+      - ./otel/prometheus.yaml:/etc/prometheus/prometheus.yml:z
     ports:
       - "9091:9090"
     networks:

--- a/integration/docker-compose.pxe.yml
+++ b/integration/docker-compose.pxe.yml
@@ -12,8 +12,8 @@ services:
       NODE_IP_RANGE_MAX: 10.127.127.253
       NODE_IP_ADDRESS: 10.127.127.3
     volumes:
-      - ./pxe/dhcpd.conf.template:/etc/dhcp/dhcpd.conf.template:ro
-      - ./pxe/grubx64.efi:/var/lib/tftpboot/grubx64.efi:ro
+      - ./pxe/dhcpd.conf.template:/etc/dhcp/dhcpd.conf.template:z,ro
+      - ./pxe/grubx64.efi:/var/lib/tftpboot/grubx64.efi:z,ro
     cap_add:
       - CAP_NET_BIND_SERVICE
       - CAP_NET_RAW

--- a/integration/gateway/Dockerfile
+++ b/integration/gateway/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:1.23.1-alpine
+FROM docker.io/library/nginx:1.23.1-alpine
 COPY ./errors.grpc_conf /etc/nginx/conf.d/
 COPY ./grpc_gateway.conf /etc/nginx/conf.d/

--- a/integration/gateway/Dockerfile.storage
+++ b/integration/gateway/Dockerfile.storage
@@ -1,7 +1,7 @@
 # This Dockerfile runs the helloworld server from
 # https://grpc.io/docs/quickstart/go.html
 
-FROM golang:1.18.4-alpine
+FROM docker.io/library/golang:1.18.4-alpine
 ADD https://github.com/grpc/grpc-go/archive/v1.48.0.tar.gz .
 RUN tar -zxvf v1.48.0.tar.gz
 WORKDIR grpc-go-1.48.0/examples/helloworld

--- a/integration/xpu-cpu/Dockerfile.telegraf
+++ b/integration/xpu-cpu/Dockerfile.telegraf
@@ -1,2 +1,2 @@
-FROM telegraf:1.23.2
+FROM docker.io/library/telegraf:1.23.2
 COPY telegraf-redfish.conf /etc/telegraf/telegraf.conf


### PR DESCRIPTION
* Specify public cr to use for public images
* Use SELinux :z on prometheus volume
* Can use pip installed version of docker-compose

Signed-off-by: Steven Royer <sroyer@redhat.com>