### PR TITLE
storage-skip: Match job name

### DIFF
--- a/.github/workflows/poc-storage-skip.yml
+++ b/.github/workflows/poc-storage-skip.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - run: 'echo "No storage shellcheck test run required"'
 
-  run_storage_poc:
+  docker-build:
     needs: storage-shellcheck
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The job names of the storage-poc changed, but we neglected to update it
in the skip job. This commit fixes that.

Signed-off-by: Kyle Mestery <mestery@mestery.com>