### PR TITLE
Workaround for spdk illegal instruction

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -42,11 +42,20 @@ This pulls the latest images and only builds those it cannot find.
 ```
 
 If you are making changes to the container images, you can `build` them before
-running `start`.
+running `start`.  **Note** This does not work for images pulled from a cr like
+the spdk-target image.
 
 ```bash
 ./scripts/integration.sh build
 ./scripts/integration.sh start
+```
+
+If you try to run on a platform that does not support every extended instruction
+that SPDK supports, the pulled spdk-target image will not function.  To work
+around this, set the `BUILD_SPDK` variable before starting:
+
+```bash
+BUILD_SPDK=1 ./scripts/integration.sh start
 ```
 
 ### Start - Red Hat

--- a/integration/scripts/integration.sh
+++ b/integration/scripts/integration.sh
@@ -32,6 +32,10 @@ start_containers() {
     bash -c "${DC} down"
     docker network prune --force
     bash -c "${DC} pull"
+    # Workaround for running on servers without AVX512
+    if [ -n "${BUILD_SPDK:-}" ]; then
+        bash -c "${DC} build spdk-target"
+    fi
     bash -c "${DC} up -d"
 }
 


### PR DESCRIPTION
This is a workaround for issue
https://github.com/opiproject/opi-poc/issues/207

Setting BUILD_SPDK to any value will cause it to build spdk-target
service after the pull when doing integration.sh start

Signed-off-by: Steven Royer <sroyer@redhat.com>