### PR TITLE
Support SELinux volume mounts for strongswan

### DIFF
--- a/integration/docker-compose.pxe.yml
+++ b/integration/docker-compose.pxe.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - 8082:8082
     volumes:
-      - ./pxe/grubx64.efi:/var/lib/tftpboot/grubx64.efi:ro
+      - ./pxe/grubx64.efi:/var/lib/tftpboot/grubx64.efi:z,ro
     networks:
       xpu-cpu:
         ipv4_address: 10.127.127.16

--- a/integration/docker-compose.xpu.yml
+++ b/integration/docker-compose.xpu.yml
@@ -107,8 +107,8 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - ./strongswan/server:/etc/swanctl
-      - ./strongswan/strongswan.conf:/etc/strongswan.conf
+      - ./strongswan/server:/etc/swanctl:z
+      - ./strongswan/strongswan.conf:/etc/strongswan.conf:z
     network_mode: service:xpu-cpu-ssh
     command: './charon'
 


### PR DESCRIPTION
Without SELinux tags on the volume mounts, strongswan exits with rc 64
when running with SELinux Enforcing

Also adding a tag for pxe that was missed previously.

Signed-off-by: Steven Royer <sroyer@redhat.com>