### PR TITLE
storage: ARCH=skylake to avoid using too new ISA

### DIFF
--- a/storage/Dockerfile
+++ b/storage/Dockerfile
@@ -4,7 +4,9 @@
 FROM fedora:36 as build
 
 ARG TAG=v22.05
-ARG ARCH=x86_64
+# Pick an arch that has at least sse 4.2 but does not require newer avx
+# See https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
+ARG ARCH=skylake
 
 WORKDIR /root
 RUN dnf install -y git rpm-build diffutils procps-ng pip && dnf clean all
@@ -14,7 +16,7 @@ RUN git clone https://github.com/spdk/spdk --branch ${TAG} --depth 1 && \
     cd spdk && git submodule update --init --depth 1 && scripts/pkgdep.sh --rdma
 
 # hadolint ignore=DL3003
-RUN cd spdk && ./rpmbuild/rpm.sh --without-uring --without-crypto \
+RUN cd spdk && ./rpmbuild/rpm.sh --target-arch=${ARCH} --without-uring --without-crypto \
     --without-fio --with-raid5 --with-vhost --without-pmdk --without-rbd \
     --with-rdma --with-shared --with-iscsi-initiator --without-vtune --without-isal
 


### PR DESCRIPTION
'native' arch will cause gcc to optimize using the latest available
instructions on the build CPU.  If the build CPU is newer than the
runtime CPU, it will fail with "Illegal instruction".  'skylake' is
new enough to support the minimum ISA required by spdk/dpdk but old
enough to be largely available.
    
Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
Signed-off-by: Steven Royer <sroyer@redhat.com>
