### PR TITLE
Make example clients tolerant of startup times

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -21,7 +21,7 @@ docker-compose does work on Red Hat OSes starting with podman 3.x.
 For example:
 
 ```bash
-sudo dnf install -y podman podman-docker
+sudo dnf install -y podman podman-docker podman-plugins
 sudo systemctl enable podman.socket --now
 ```
 

--- a/integration/docker-compose.xpu.yml
+++ b/integration/docker-compose.xpu.yml
@@ -181,7 +181,12 @@ services:
       context: gateway
       dockerfile: Dockerfile.network
     network_mode: host
-    command: ['python', 'route_guide_client.py']
+    command: |
+        sh -x -c 'for i in `seq 1 5`; \
+            do \
+                sleep 1; \
+                python route_guide_client.py && break; \
+            done'
   example-storage-client:
     depends_on:
       - gateway
@@ -191,7 +196,12 @@ services:
       context: gateway
       dockerfile: Dockerfile.storage
     network_mode: host
-    command: ['go', 'run', './greeter_client/main.go']
+    command: |
+        sh -x -c 'for i in `seq 1 5`; \
+            do \
+                sleep 1; \
+                go run ./greeter_client/main.go && break; \
+            done'
 
 networks:
   xpu-cpu:


### PR DESCRIPTION
docker-compose makes little in the way of guarantees for start up time
dependencies.  If one container needs another to be running, it must
be tolerant of that container's start up time.

* Add loops to retry example tests
* Add podman-plugins as required for podman environments

Signed-off-by: Steven Royer <sroyer@redhat.com>