### PR TITLE
security: Change startup order

### DIFF
--- a/security/docker-compose.yml
+++ b/security/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.7'
 services:
   strongswan:
     image: strongx509/strongswan:5.9.6
+    depends_on:
+      - vpn-client
     cap_add:
       - NET_ADMIN
       - SYS_ADMIN
@@ -22,8 +24,6 @@ services:
 
   vpn-client:
     image: strongx509/strongswan:5.9.6
-    depends_on:
-      - strongswan
     cap_add:
       - NET_ADMIN
       - SYS_ADMIN


### PR DESCRIPTION
Sometimes, the vpn-client container fails to start with the following
message:

```
ERROR: for vpn-client  Cannot start service vpn-client: Address already in use
```

The Dockerfile for the strongSwan image we are using exposes ports [1].
It's unclear why this conflicts, but my theory is that we are running
`charon` at start which will bind to those ports, and if that happens
before the client starts, the docker daemon will not start the
vpn-client container.

This moves the vpn-client container to start before the strongswan
container to resolve this issue.

Fixes #252

[1] https://github.com/strongX509/docker/blob/master/strongswan/Dockerfile#L36

Signed-off-by: Kyle Mestery <mestery@mestery.com>