### PR TITLE
Storage: Use generic x86-64-v2

### DIFF
--- a/storage/Dockerfile
+++ b/storage/Dockerfile
@@ -6,7 +6,7 @@ FROM fedora:36 as build
 ARG TAG=v22.05
 # Pick an arch that has at least sse 4.2 but does not require newer avx
 # See https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
-ARG ARCH=skylake
+ARG ARCH=x86-64-v2
 
 WORKDIR /root
 RUN dnf install -y git rpm-build diffutils procps-ng pip && dnf clean all

--- a/storage/client/Dockerfile
+++ b/storage/client/Dockerfile
@@ -2,7 +2,7 @@
 
 # Alpine is chosen for its small footprint
 # compared to Ubuntu
-FROM golang:1.18-alpine
+FROM docker.io/library/golang:1.18-alpine
 
 WORKDIR /app
 

--- a/storage/scripts/poc.sh
+++ b/storage/scripts/poc.sh
@@ -5,6 +5,8 @@
 
 set -euxo pipefail
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 # DOCKER_COMPOSE setup
 DC=docker-compose
 
@@ -18,6 +20,10 @@ usage() {
 }
 
 tests_poc() {
+    if [ "$(uname -m)" == "x86_64" ]; then
+        # Show x86-64-v level.
+        "${SCRIPT_DIR}"/x86v.sh
+    fi
     $DC ps -a
     for i in $(seq 1 20)
     do

--- a/storage/scripts/x86v.sh
+++ b/storage/scripts/x86v.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/awk -f
+# SPDX-License-Identifier: Apache-2.0
+# From https://unix.stackexchange.com/questions/631217/how-do-i-check-if-my-cpu-supports-x86-64-v2
+
+BEGIN {
+    while (!/flags/) if (getline < "/proc/cpuinfo" != 1) exit 1
+    if (/lm/&&/cmov/&&/cx8/&&/fpu/&&/fxsr/&&/mmx/&&/syscall/&&/sse2/) level = 1
+    if (level == 1 && /cx16/&&/lahf/&&/popcnt/&&/sse4_1/&&/sse4_2/&&/ssse3/) level = 2
+    if (level == 2 && /avx/&&/avx2/&&/bmi1/&&/bmi2/&&/f16c/&&/fma/&&/abm/&&/movbe/&&/xsave/) level = 3
+    if (level == 3 && /avx512f/&&/avx512bw/&&/avx512cd/&&/avx512dq/&&/avx512vl/) level = 4
+    if (level > 0) { print "CPU supports x86-64-v" level; exit 0 }
+    exit 1
+}

--- a/storage/server/Dockerfile
+++ b/storage/server/Dockerfile
@@ -2,7 +2,7 @@
 
 # Alpine is chosen for its small footprint
 # compared to Ubuntu
-FROM golang:1.18-alpine
+FROM docker.io/library/golang:1.18-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
DPDK requires a minimum x86 arch level that includes sse4.2.  gcc
provides a set of generic x86-64-v levels for different architecture
versions.  Version 2 is the minimum that meets the requirements for
DPDK.

* Set x86-64-v2 for spdk container
* Print actual x86-64-v level
* Specify cr to use for golang containers for podman

Signed-off-by: Steven Royer <sroyer@redhat.com>