### PR TITLE
security: Connection up and down

### DIFF
--- a/security/client/ipsec.go
+++ b/security/client/ipsec.go
@@ -20,6 +20,7 @@ func do_ipsec(conn grpc.ClientConnInterface, ctx context.Context) {
 		Connection: &pb.Connection {
 			Name: "opi-test",
 			Version: "2",
+			Vips: &pb.Vips { Vip: []string { "0.0.0.0", }, },
 			LocalAddrs: []*pb.Addrs {
 				{
 					Addr: "192.168.200.200",
@@ -30,6 +31,8 @@ func do_ipsec(conn grpc.ClientConnInterface, ctx context.Context) {
 					Addr: "192.168.200.210",
 				},
 			},
+			LocalAuth: &pb.LocalAuth { Auth: pb.AuthType_PSK, Id: "hacker@strongswan.org" },
+			RemoteAuth: &pb.RemoteAuth { Auth: pb.AuthType_PSK, Id: "server.strongswan.org" },
 			Proposals: &pb.Proposals {
 					CryptoAlg: []pb.CryptoAlgorithm { pb.CryptoAlgorithm_AES256GCM128 },
 					IntegAlg: []pb.IntegAlgorithm { pb.IntegAlgorithm_SHA256_96 },
@@ -39,9 +42,16 @@ func do_ipsec(conn grpc.ClientConnInterface, ctx context.Context) {
 				{
 					Name: "opi-child",
 					EspProposals: &pb.Proposals {
-							CryptoAlg: []pb.CryptoAlgorithm { pb.CryptoAlgorithm_AES256GMAC },
-							IntegAlg: []pb.IntegAlgorithm { pb.IntegAlgorithm_SHA512 },
-							Dhgroups: []pb.DiffieHellmanGroups { pb.DiffieHellmanGroups_CURVE25519 },
+						CryptoAlg: []pb.CryptoAlgorithm { pb.CryptoAlgorithm_AES256GCM128 },
+						IntegAlg: []pb.IntegAlgorithm { pb.IntegAlgorithm_SHA512 },
+						Dhgroups: []pb.DiffieHellmanGroups { pb.DiffieHellmanGroups_CURVE25519 },
+					},
+					RemoteTs: &pb.TrafficSelectors {
+						Ts: []*pb.TrafficSelectors_TrafficSelector {
+							{
+								Cidr: "10.1.0.0/16",
+							},
+						},
 					},
 				},
 			},
@@ -54,8 +64,32 @@ func do_ipsec(conn grpc.ClientConnInterface, ctx context.Context) {
 	}
 	log.Printf("Loaded: %v", rs1)
 
-	// Unload
+	// Bring the connection up
+	init_conn := pb.IPsecInitiateReq {
+		Ike: "opi-test",
+		Child: "opi-child",
+	}
 
+	init_ret, err := c1.IPsecInitiate(ctx, &init_conn)
+	if err != nil {
+		log.Fatalf("could not initiate IPsec tunnel: %v", err)
+	}
+	log.Printf("Initiated: %v", init_ret)
+
+	// Terminate the connection
+	term_conn := pb.IPsecTerminateReq{
+		Ike: "opi-test",
+		Child: "opi-child",
+	}
+
+	term_ret, err := c1.IPsecTerminate(ctx, &term_conn)
+	if err != nil {
+		log.Fatalf("could not terminate IPsec tunnel: %v", err)
+	}
+	log.Printf("Initiated: %v", term_ret)
+
+
+	// Unload
 	unload_ipsec := pb.IPsecUnloadConnReq {
 		Name: "opi-test",
 	}

--- a/security/docker-compose.yml
+++ b/security/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - /var/run
     networks:
       internet:
-        ipv4_address: 192.168.0.2
+        ipv4_address: 192.168.200.210
       intranet:
         ipv4_address: 10.1.0.2
     command: './charon'
@@ -36,7 +36,7 @@ services:
       - /var/run
     networks:
       internet:
-        ipv4_address: 192.168.0.3
+        ipv4_address: 192.168.200.200
     command: './charon'
 
   opi-security-server:
@@ -65,7 +65,7 @@ networks:
     ipam:
       driver: default 
       config:
-        - subnet: 192.168.0.0/24
+        - subnet: 192.168.200.0/24
   intranet:
     ipam:
       driver: default

--- a/security/server/ipsec.go
+++ b/security/server/ipsec.go
@@ -19,11 +19,35 @@ func (s *server) IPsecStats(ctx context.Context, in *pb.IPsecStatsReq) (*pb.IPse
 }
 
 func (s *server) IPsecInitiate(ctx context.Context, in *pb.IPsecInitiateReq) (*pb.IPsecInitiateResp, error) {
-	return nil, nil
+	log.Printf("IPsecInitiate: Received: %v", in)
+
+	err := initiateConn(in)
+	if err != nil {
+		log.Printf("IPsecInitiate: Failed %v", err)
+		return nil, err
+	}
+
+	ip_ret := pb.IPsecInitiateResp{
+	}
+
+	return &ip_ret, nil
 }
 
 func (s *server) IPsecTerminate(ctx context.Context, in *pb.IPsecTerminateReq) (*pb.IPsecTerminateResp, error) {
-	return nil, nil
+	log.Printf("IPsecTerminate: Received: %v", in)
+
+	matches, err := terminateConn(in)
+	if err != nil {
+		log.Printf("IPsecTerminate: Failed %v", err)
+		return nil, err
+	}
+
+	ip_ret := pb.IPsecTerminateResp {
+		Success: "Yes",
+		Matches: matches,
+	}
+
+	return &ip_ret, nil
 }
 
 func (s *server) IPsecRekey(ctx context.Context, in *pb.IPsecRekeyReq) (*pb.IPsecRekeyResp, error) {


### PR DESCRIPTION
This commit gets initiate and terminate working.

Related to #220

```
vagrant@bullseye:/git/opi-poc/security$ docker logs security-opi-security-server-1
2022/08/18 19:47:06 server listening at [::]:50151
2022/08/18 19:47:07 IPsecLoadConn: Received: name:"opi-test" version:"2" local_addrs:{addr:"192.168.200.200"} remote_addrs:{addr:"192.168.200.210"} proposals:{crypto_alg:AES256GCM128 integ_alg:SHA256_96 dhgroups:CURVE25519} vips:{vip:"0.0.0.0"} local_auth:{auth:PSK id:"hacker@strongswan.org"} remote_auth:{auth:PSK id:"server.strongswan.org"} children:{name:"opi-child" esp_proposals:{crypto_alg:AES256GCM128 integ_alg:SHA512 dhgroups:CURVE25519} remote_ts:{ts:{cidr:"10.1.0.0/16"}}}
2022/08/18 19:47:07 DUMPING conn.Local: {psk [] hacker@strongswan.org    []}
2022/08/18 19:47:07 DUMPING conn.Remove: {psk server.strongswan.org  [] [] [] [] []}
2022/08/18 19:47:07 Dumping local_ts [[]] remote_ts [[10.1.0.0/16]]
2022/08/18 19:47:07 Dumping child object: {[10.1.0.0/16] []  [aes256gcm128-sha512-curve25519] }
2022/08/18 19:47:07 Dumping connection object: &{opi-test [192.168.200.200] [192.168.200.210] {psk [] hacker@strongswan.org    []} {psk server.strongswan.org  [] [] [] [] []} map[opi-child:{[10.1.0.0/16] []  [aes256gcm128-sha512-curve25519] }] 2 []  [0.0.0.0]}
2022/08/18 19:47:07 Marshaled connection request: &{[local_addrs remote_addrs local remote children version vips] map[children:0xc0000aeaa0 local:0xc0000aea20 local_addrs:[192.168.200.200] remote:0xc0000aea60 remote_addrs:[192.168.200.210] version:2 vips:[0.0.0.0]]}
2022/08/18 19:47:07 command error return [<nil>]
2022/08/18 19:47:07 IPsecInitiate: Received: child:"opi-child" ike:"opi-test"
2022/08/18 19:47:07 Dumping connection to initiate: &{opi-child opi-test 0  }
2022/08/18 19:47:07 Marshaled vici message: &{[child ike timeout] map[child:opi-child ike:opi-test timeout:0]}
2022/08/18 19:47:07 command error return [<nil>]
2022/08/18 19:47:07 IPsecTerminate: Received: child:"opi-child" ike:"opi-test"
2022/08/18 19:47:07 Dumping connection to terminate: &{opi-child opi-test    0 }
2022/08/18 19:47:07 Marshaled vici message: &{[child ike timeout] map[child:opi-child ike:opi-test timeout:0]}
2022/08/18 19:47:07 command error return [<nil>]
2022/08/18 19:47:07 IPsecUnloadConn: Received: opi-test
2022/08/18 19:47:07 Dumping connection to unload: &{opi-test}
2022/08/18 19:47:07 Marshaled vici message: &{[name] map[name:opi-test]}
2022/08/18 19:47:07 command error return [<nil>]
vagrant@bullseye:/git/opi-poc/security$
```

Signed-off-by: Kyle Mestery <mestery@mestery.com>