### PR TITLE
security: Finish implementing APIs

### DIFF
--- a/security/client/go.mod
+++ b/security/client/go.mod
@@ -3,7 +3,7 @@ module main
 go 1.18
 
 require (
-	github.com/opiproject/opi-api v0.0.0-20220824210047-034263365d32
+	github.com/opiproject/opi-api v0.0.0-20220829200214-c600af00004f
 	google.golang.org/grpc v1.49.0
 )
 

--- a/security/client/go.sum
+++ b/security/client/go.sum
@@ -23,8 +23,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/opiproject/opi-api v0.0.0-20220824210047-034263365d32 h1://7y2UCei+9g23quZvOcay77cRzuPQ64LigMVp8dfx4=
-github.com/opiproject/opi-api v0.0.0-20220824210047-034263365d32/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
+github.com/opiproject/opi-api v0.0.0-20220829200214-c600af00004f h1:bjN8/KmNFA+tPwEuk5ETRqRfB+8eDnv0eH+CUbqKfSQ=
+github.com/opiproject/opi-api v0.0.0-20220829200214-c600af00004f/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/security/client/ipsec.go
+++ b/security/client/ipsec.go
@@ -102,6 +102,28 @@ func do_ipsec(conn grpc.ClientConnInterface, ctx context.Context) {
 	}
 	log.Printf("Returned IKE_SAs: %v", list_sas_ret)
 
+	// List the connections
+	list_conn := pb.IPsecListConnsReq {
+		Ike: "opi-test",
+	}
+
+	list_conns_ret, err := c1.IPsecListConns(ctx, &list_conn)
+	if err != nil {
+		log.Fatalf("could not list connections: %v", err)
+	}
+	log.Printf("Returned connections: %v", list_conns_ret)
+
+	// List the certificats
+	list_certs := pb.IPsecListCertsReq {
+		Type: "any",
+	}
+
+	list_certs_ret, err := c1.IPsecListCerts(ctx, &list_certs)
+	if err != nil {
+		log.Fatalf("could not list certificates: %v", err)
+	}
+	log.Printf("Returned connections: %v", list_certs_ret)
+
 	// Rekey the IKE_SA
 	rekey_conn := pb.IPsecRekeyReq {
 		Ike: "opi-test",

--- a/security/server/go.mod
+++ b/security/server/go.mod
@@ -3,7 +3,7 @@ module main
 go 1.18
 
 require (
-	github.com/opiproject/opi-api v0.0.0-20220824210047-034263365d32
+	github.com/opiproject/opi-api v0.0.0-20220829200214-c600af00004f
 	github.com/strongswan/govici v0.6.0
 	google.golang.org/grpc v1.49.0
 )

--- a/security/server/go.sum
+++ b/security/server/go.sum
@@ -3,8 +3,8 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/opiproject/opi-api v0.0.0-20220824210047-034263365d32 h1://7y2UCei+9g23quZvOcay77cRzuPQ64LigMVp8dfx4=
-github.com/opiproject/opi-api v0.0.0-20220824210047-034263365d32/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
+github.com/opiproject/opi-api v0.0.0-20220829200214-c600af00004f h1:bjN8/KmNFA+tPwEuk5ETRqRfB+8eDnv0eH+CUbqKfSQ=
+github.com/opiproject/opi-api v0.0.0-20220829200214-c600af00004f/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
 github.com/strongswan/govici v0.6.0 h1:QAjc7IIx1c/1P0Hz7yMX91FB5BUNKtyXzfxpuPyBKXE=
 github.com/strongswan/govici v0.6.0/go.mod h1:RgO/KrMlFNsRf3dSoxwWSDSV+ASd98n1T+2G3QMEVHE=
 golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48 h1:N9Vc/rorQUDes6B9CNdIxAn5jODGj2wzfrei2x4wNj4=

--- a/security/server/ipsec.go
+++ b/security/server/ipsec.go
@@ -92,11 +92,27 @@ func (s *server) IPsecListSas(ctx context.Context, in *pb.IPsecListSasReq) (*pb.
 }
 
 func (s *server) IPsecListConns(ctx context.Context, in *pb.IPsecListConnsReq) (*pb.IPsecListConnsResp, error) {
-	return nil, nil
+	log.Printf("IPsecListConns: Received: %v", in)
+
+	ret, err := listConns(in)
+	if err != nil {
+		log.Printf("IPsecListConns: Failed: %v", err)
+		return nil, err
+	}
+
+	return ret, nil
 }
 
 func (s *server) IPsecListCerts(ctx context.Context, in *pb.IPsecListCertsReq) (*pb.IPsecListCertsResp, error) {
-	return nil, nil
+	log.Printf("IPsecListCerts: Received: %v", in)
+
+	ret, err := listCerts(in)
+	if err != nil {
+		log.Printf("IPsecListConns: Failed: %v", err)
+		return nil, err
+	}
+
+	return ret, nil
 }
 
 func (s *server) IPsecLoadConn(ctx context.Context, in *pb.IPsecLoadConnReq) (*pb.IPsecLoadConnResp, error) {

--- a/security/server/ipsec_vici_parse.go
+++ b/security/server/ipsec_vici_parse.go
@@ -4,13 +4,15 @@
 package main
 
 import (
+	"encoding/base64"
         "log"
+	"strings"
 
         pb "github.com/opiproject/opi-api/security/proto"
 )
 
 func parse_child_list_sas(childsa list_child_sa, name string) (*pb.ListChildSa, error) {
-	log.Printf("Found key %v", childsa )
+	log.Printf("Found key %v", childsa)
 
 	child := &pb.ListChildSa {}
 
@@ -192,6 +194,265 @@ func parse_ike_list_sas(ikesa *list_ike_sa, km string) (*pb.ListIkeSa, error) {
 			}
 			list_ret.Childsas = append(list_ret.Childsas, childsa)
 		}
+	}
+
+	return list_ret, nil
+}
+
+func parse_auth(conn_auth list_auth, name string) (*pb.ListConnAuth, error) {
+	log.Printf("Found key %v", conn_auth)
+
+	auth := &pb.ListConnAuth{}
+
+	if conn_auth.Class != "" {
+		auth.Class = conn_auth.Class
+	}
+	if conn_auth.EapType != "" {
+		auth.Eaptype = conn_auth.EapType
+	}
+	if conn_auth.EapVendor != "" {
+		auth.Eapvendor = conn_auth.EapVendor
+	}
+	if conn_auth.Xauth != "" {
+		auth.Xauth = conn_auth.Xauth
+	}
+	if conn_auth.Revocation != "" {
+		auth.Revocation = conn_auth.Revocation
+	}
+	if conn_auth.Id != "" {
+		auth.Id = conn_auth.Id
+	}
+	if conn_auth.CaId != "" {
+		auth.CaId = conn_auth.CaId
+	}
+	if conn_auth.AaaId != "" {
+		auth.AaaId = conn_auth.AaaId
+	}
+	if conn_auth.EapId != "" {
+		auth.EapId = conn_auth.EapId
+	}
+	if conn_auth.XauthId != "" {
+		auth.XauthId = conn_auth.XauthId
+	}
+	if conn_auth.Groups != nil {
+		for k := 0; k < len(conn_auth.Groups); k++ {
+			auth.Group.Group = append(auth.Group.Group, conn_auth.Groups[k])
+		}
+	}
+	if conn_auth.CertPolicy != nil {
+		for k := 0; k < len(conn_auth.CertPolicy); k++ {
+			auth.CertPolicy.CertPolicy = append(auth.CertPolicy.CertPolicy, conn_auth.CertPolicy[k])
+		}
+	}
+	if conn_auth.Certs != nil {
+		for k := 0; k < len(conn_auth.Certs); k++ {
+			auth.Certs.Cert = append(auth.Certs.Cert, conn_auth.Certs[k])
+		}
+	}
+	if conn_auth.CaCerts != nil {
+		for k := 0; k < len(conn_auth.CaCerts); k++ {
+			auth.Cacerts.Cacert = append(auth.Cacerts.Cacert, conn_auth.CaCerts[k])
+		}
+	}
+
+	return auth, nil
+}
+
+func parse_connection_child(list_child list_child, name string) (*pb.ListChild, error) {
+	log.Printf("Found key %v", list_child)
+
+	child := &pb.ListChild {}
+
+	child.Name = name
+	if list_child.Mode != "" {
+		child.Mode = list_child.Mode
+	}
+	if list_child.Label != "" {
+		child.Label = list_child.Label
+	}
+	if list_child.RekeyTime != 0 {
+		child.RekeyTime = list_child.RekeyTime
+	}
+	if list_child.RekeyBytes != 0 {
+		child.RekeyBytes = list_child.RekeyBytes
+	}
+	if list_child.RekeyPackets != 0 {
+		child.RekeyPackets = list_child.RekeyPackets
+	}
+	if list_child.DpdAction != "" {
+		child.DpdAction = list_child.DpdAction
+	}
+	if list_child.CloseAction != "" {
+		child.CloseAction = list_child.CloseAction
+	}
+	if list_child.RemoteTs != nil {
+		for k := 0; k < len(list_child.RemoteTs); k++ {
+			s := strings.Split(list_child.RemoteTs[k], ":")
+			ts := &pb.TrafficSelectors_TrafficSelector {}
+			if len(s) >= 1 && s[0] != "" {
+				ts.Cidr =s[0]
+			}
+			if len(s) >= 2 && s[1] != "" {
+				ts.Proto = s[1]
+			}
+			if len(s) >= 3 && s[2] != "" {
+				ts.Port = s[2]
+			}
+
+			child.RemoteTs = &pb.TrafficSelectors {}
+			child.RemoteTs.Ts = []*pb.TrafficSelectors_TrafficSelector {}
+			child.RemoteTs.Ts = append(child.RemoteTs.Ts, ts)
+		}
+	}
+	if list_child.LocalTs != nil {
+		for k := 0; k < len(list_child.LocalTs); k++ {
+			s := strings.Split(list_child.LocalTs[k], ":")
+			ts := &pb.TrafficSelectors_TrafficSelector {}
+			if len(s) >= 1 && s[0] != "" {
+				ts.Cidr =s[0]
+			}
+			if len(s) >= 2 && s[1] != "" {
+				ts.Proto = s[1]
+			}
+			if len(s) >= 3 && s[2] != "" {
+				ts.Port = s[2]
+			}
+
+			child.LocalTs = &pb.TrafficSelectors {}
+			child.LocalTs.Ts = []*pb.TrafficSelectors_TrafficSelector {}
+			child.LocalTs.Ts = append(child.LocalTs.Ts, ts)
+		}
+	}
+	if list_child.Interface != "" {
+		child.Interface = list_child.Interface
+	}
+	if list_child.Priority != "" {
+		child.Priority = list_child.Priority
+	}
+
+	return child, nil
+}
+
+func parse_connection(conn *list_ike, km string) (*pb.ListConnResp, error) {
+	list_ret := &pb.ListConnResp {}
+
+	list_ret.Name = km
+	for i := 0; i < len(conn.LocalAddrs); i++ {
+		addr := &pb.Addrs { Addr: conn.LocalAddrs[i], }
+		list_ret.LocalAddrs = append(list_ret.LocalAddrs, addr)
+	}
+	for i := 0 ; i < len(conn.RemoteAddrs); i++ {
+		addr := &pb.Addrs { Addr: conn.RemoteAddrs[i], }
+		list_ret.RemoteAddrs = append(list_ret.RemoteAddrs, addr)
+	}
+	if conn.Version != "" {
+		list_ret.Version = conn.Version
+	}
+	if conn.ReauthTime != 0 {
+		list_ret.ReauthTime = conn.ReauthTime
+	}
+	if conn.RekeyTime != 0 {
+		list_ret.RekeyTime = conn.RekeyTime
+	}
+	if conn.Unique!= "" {
+		list_ret.Unique= conn.Unique
+	}
+	if conn.DpdDelay != 0 {
+		list_ret.DpdDelay = conn.DpdDelay
+	}
+	if conn.DpdTimeout != 0 {
+		list_ret.DpdTimeout = conn.DpdTimeout
+	}
+	if conn.Ppk != "" {
+		list_ret.Ppk = conn.Ppk
+	}
+	if conn.PpkRequired != "" {
+		list_ret.PpkRequired = conn.PpkRequired
+	}
+	if conn.Local != nil {
+		log.Printf("Looking at Local Auth%v", conn.Local)
+		for k, mess := range conn.Local {
+			local, err := parse_auth(mess, k)
+			if err != nil {
+				log.Printf("Error parsing local auth")
+				return nil, nil
+			}
+			list_ret.LocalAuth = append(list_ret.LocalAuth, local)
+		}
+	}
+	if conn.Remote != nil {
+		log.Printf("Looking at Remote Auth%v", conn.Remote)
+		for k, mess := range conn.Remote {
+			remote, err := parse_auth(mess, k)
+			if err != nil {
+				log.Printf("Error parsing remote auth")
+				return nil, nil
+			}
+			list_ret.RemoteAuth = append(list_ret.RemoteAuth, remote)
+		}
+	}
+	if conn.Children != nil {
+		log.Printf("Looking at Children%v", conn.Children)
+		for k, mess := range conn.Children {
+			child, err := parse_connection_child(mess, k)
+			if err != nil {
+				log.Printf("Error parsing child")
+				return nil, nil
+			}
+			list_ret.Children = append(list_ret.Children, child)
+		}
+	}
+
+
+	return list_ret, nil
+}
+
+func parse_certificate(cert *list_cert) (*pb.ListCert, error) {
+	list_ret := &pb.ListCert {}
+
+	if cert.Type != "" {
+		s1 := strings.ToUpper(cert.Type)
+
+		if strings.Contains(s1, "X509_AC") {
+			list_ret.Type = pb.CertificateType_CERT_X509
+		} else if strings.Contains(s1, "X509_CRL") {
+			list_ret.Type = pb.CertificateType_CERT_X509_CRL
+		} else if strings.Contains(s1, "X509") {
+			list_ret.Type = pb.CertificateType_CERT_X509
+		} else if strings.Contains(s1, "OCSP_RESPONSE") {
+			list_ret.Type = pb.CertificateType_CERT_OCSP_RESPONSE
+		} else if strings.Contains(s1, "PUBKEY") {
+			list_ret.Type = pb.CertificateType_CERT_PUBKEY
+		}
+	}
+	if cert.Flag != "" {
+		s1 := strings.ToUpper(cert.Flag)
+
+		if strings.Contains(s1, "OCSP") {
+			list_ret.Flag = pb.X509CertificateFlag_X509_CERT_FLAG_OCSP
+		} else if strings.Contains(s1, "AA") {
+			list_ret.Flag = pb.X509CertificateFlag_X509_CERT_FLAG_AA
+		} else if strings.Contains(s1, "CA") {
+			list_ret.Flag = pb.X509CertificateFlag_X509_CERT_FLAG_CA
+		} else if strings.Contains(s1, "NONE") {
+			list_ret.Flag = pb.X509CertificateFlag_X509_CERT_FLAG_NONE
+		}
+	}
+	if cert.HasPrivKey != "" {
+		list_ret.Hasprivkey = cert.HasPrivKey
+	}
+	if cert.Data != "" {
+		encodedText := base64.StdEncoding.EncodeToString([]byte(cert.Data))
+		list_ret.Data = encodedText
+	}
+	if cert.Subject != "" {
+		list_ret.Subject = cert.Subject
+	}
+	if cert.NotBefore != "" {
+		list_ret.Notbefore = cert.NotBefore
+	}
+	if cert.NotAfter != "" {
+		list_ret.Notafter = cert.NotAfter
 	}
 
 	return list_ret, nil


### PR DESCRIPTION
This implements the final two OPI Security IPsec APIs:

* IPsecListConns()
* IPsecListCerts()

With these now implemented, all of the APIs are now shown here, and are
tested in the CI, as the client calls them all. Should be a good example
for vendors to look at.

Related to #320

Signed-off-by: Kyle Mestery <mestery@mestery.com>