### PR TITLE
Issue#337: Fixing storage poc wrt nqn/id related changes

### DIFF
--- a/storage/client/frontend.go
+++ b/storage/client/frontend.go
@@ -27,17 +27,17 @@ func do_frontend(conn grpc.ClientConnInterface, ctx context.Context) {
 		log.Fatalf("could not list NVMe subsystem: %v", err)
 	}
 	log.Printf("Listed: %v", rs4)
-	rs5, err := c1.NVMeSubsystemGet(ctx, &pb.NVMeSubsystemGetRequest{Id: 7})
+	rs5, err := c1.NVMeSubsystemGet(ctx, &pb.NVMeSubsystemGetRequest{Nqn: "7"})
 	if err != nil {
 		log.Fatalf("could not get NVMe subsystem: %v", err)
 	}
 	log.Printf("Got: %s", rs5.Subsystem.Nqn)
-	rs6, err := c1.NVMeSubsystemStats(ctx, &pb.NVMeSubsystemStatsRequest{Id: 7})
+	rs6, err := c1.NVMeSubsystemStats(ctx, &pb.NVMeSubsystemStatsRequest{Nqn: "7"})
 	if err != nil {
 		log.Fatalf("could not stats NVMe subsystem: %v", err)
 	}
 	log.Printf("Stats: %s", rs6.Stats)
-	rs2, err := c1.NVMeSubsystemDelete(ctx, &pb.NVMeSubsystemDeleteRequest{Id: 7})
+	rs2, err := c1.NVMeSubsystemDelete(ctx, &pb.NVMeSubsystemDeleteRequest{Nqn: "7"})
 	if err != nil {
 		log.Fatalf("could not delete NVMe subsystem: %v", err)
 	}

--- a/storage/client/go.mod
+++ b/storage/client/go.mod
@@ -3,7 +3,7 @@ module opi.storage.v1
 go 1.18
 
 require (
-	github.com/opiproject/opi-api v0.0.0-20220809123138-dc09853bd22d
+	github.com/opiproject/opi-api v0.0.0-20220907165626-e3062bc126fb
 	google.golang.org/grpc v1.49.0
 )
 

--- a/storage/client/go.sum
+++ b/storage/client/go.sum
@@ -3,8 +3,8 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/opiproject/opi-api v0.0.0-20220809123138-dc09853bd22d h1:JyIPY3zNFPwWKadAWihJK9mMtUGgkRhGzaEAPA05sQs=
-github.com/opiproject/opi-api v0.0.0-20220809123138-dc09853bd22d/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
+github.com/opiproject/opi-api v0.0.0-20220907165626-e3062bc126fb h1:420u/2ETvC729oYb4I4wS3Icn6eI4+9tZomRJ1Q7NyQ=
+github.com/opiproject/opi-api v0.0.0-20220907165626-e3062bc126fb/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
 golang.org/x/net v0.0.0-20220728211354-c7608f3a8462 h1:UreQrH7DbFXSi9ZFox6FNT3WBooWmdANpU+IfkT1T4I=
 golang.org/x/net v0.0.0-20220728211354-c7608f3a8462/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/sys v0.0.0-20220731174439-a90be440212d h1:Sv5ogFZatcgIMMtBSTTAgMYsicp25MXBubjXNDKwm80=

--- a/storage/server/frontend.go
+++ b/storage/server/frontend.go
@@ -41,7 +41,7 @@ func (s *server) NVMeSubsystemDelete(ctx context.Context, in *pb.NVMeSubsystemDe
 	params := struct {
 		Name        string `json:"name"`
 	}{
-		Name:       fmt.Sprint("OpiMalloc", in.GetId()),
+		Name:       fmt.Sprint("OpiMalloc", in.GetNqn()),
 	}
 	var result bool
 	err := call("bdev_malloc_delete", &params, &result)
@@ -117,7 +117,7 @@ func (s *server) NVMeSubsystemGet(ctx context.Context, in *pb.NVMeSubsystemGetRe
 	params := struct {
 		Name string `json:"name"`
 	}{
-		Name:       fmt.Sprint("OpiMalloc", in.GetId()),
+		Name:       fmt.Sprint("OpiMalloc", in.GetNqn()),
 	}
 	var result []struct {
 		Name        string `json:"name"`
@@ -141,7 +141,7 @@ func (s *server) NVMeSubsystemStats(ctx context.Context, in *pb.NVMeSubsystemSta
 	params := struct {
 		Name string `json:"name"`
 	}{
-		Name:     fmt.Sprint("OpiMalloc", in.GetId()),
+		Name:     fmt.Sprint("OpiMalloc", in.GetNqn()),
 	}
 	// See https://mholt.github.io/json-to-go/
 	var result struct {
@@ -168,7 +168,7 @@ func (s *server) NVMeSubsystemStats(ctx context.Context, in *pb.NVMeSubsystemSta
 	if (len(result.Bdevs) != 1) {
 		log.Printf("expecting exactly 1 result")
 	}
-	return &pb.NVMeSubsystemStatsResponse{Id: 1, Stats: fmt.Sprint(result.Bdevs[0])}, nil
+	return &pb.NVMeSubsystemStatsResponse{Stats: fmt.Sprint(result.Bdevs[0])}, nil
 }
 
 //////////////////////////////////////////////////////////

--- a/storage/server/go.mod
+++ b/storage/server/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/opiproject/opi-api v0.0.0-20220809123138-dc09853bd22d
+	github.com/opiproject/opi-api v0.0.0-20220907165626-e3062bc126fb
 	google.golang.org/grpc v1.49.0
 )
 

--- a/storage/server/go.sum
+++ b/storage/server/go.sum
@@ -5,8 +5,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/opiproject/opi-api v0.0.0-20220809123138-dc09853bd22d h1:JyIPY3zNFPwWKadAWihJK9mMtUGgkRhGzaEAPA05sQs=
-github.com/opiproject/opi-api v0.0.0-20220809123138-dc09853bd22d/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
+github.com/opiproject/opi-api v0.0.0-20220907165626-e3062bc126fb h1:420u/2ETvC729oYb4I4wS3Icn6eI4+9tZomRJ1Q7NyQ=
+github.com/opiproject/opi-api v0.0.0-20220907165626-e3062bc126fb/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
 golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48 h1:N9Vc/rorQUDes6B9CNdIxAn5jODGj2wzfrei2x4wNj4=
 golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 h1:9vYwv7OjYaky/tlAeD7C4oC9EsPTlaFl1H2jS++V+ME=


### PR DESCRIPTION
Opi-api has id's removed from Subsystem api's. Also SubsystemCreateResponse now contains uuid. So updating storage poc to be in sync.

Signed-off-by: Amar Vishwakarma <amarv@marvell.com>
Signed-off-by: Michal Kalderon <mkalderon@marvell.com>