### PR TITLE
storage: return RPC error on call() error

### DIFF
--- a/storage/client/frontend.go
+++ b/storage/client/frontend.go
@@ -12,6 +12,7 @@ func do_frontend(conn grpc.ClientConnInterface, ctx context.Context) {
 
 	// NVMeSubsystem
 	c1 := pb.NewNVMeSubsystemServiceClient(conn)
+	log.Printf("Testing NewNVMeSubsystemServiceClient")
 	rs1, err := c1.NVMeSubsystemCreate(ctx, &pb.NVMeSubsystemCreateRequest{Subsystem: &pb.NVMeSubsystem{Nqn: "OpiMalloc7"}})
 	if err != nil {
 		log.Fatalf("could not create NVMe subsystem: %v", err)
@@ -45,6 +46,7 @@ func do_frontend(conn grpc.ClientConnInterface, ctx context.Context) {
 
 	// NVMeController
 	c2 := pb.NewNVMeControllerServiceClient(conn)
+	log.Printf("Testing NewNVMeControllerServiceClient")
 	rc1, err := c2.NVMeControllerCreate(ctx, &pb.NVMeControllerCreateRequest{Controller: &pb.NVMeController{Name: "OPI-Nvme"}})
 	if err != nil {
 		log.Fatalf("could not create NVMe subsystem: %v", err)
@@ -78,6 +80,7 @@ func do_frontend(conn grpc.ClientConnInterface, ctx context.Context) {
 
 	// NVMeNamespace
 	c3 := pb.NewNVMeNamespaceServiceClient(conn)
+	log.Printf("Testing NewNVMeNamespaceServiceClient")
 	rn1, err := c3.NVMeNamespaceCreate(ctx, &pb.NVMeNamespaceCreateRequest{Namespace: &pb.NVMeNamespace{Name: "OPI-Nvme"}})
 	if err != nil {
 		log.Fatalf("could not create NVMe subsystem: %v", err)
@@ -111,6 +114,7 @@ func do_frontend(conn grpc.ClientConnInterface, ctx context.Context) {
 
 	// VirtioBlk
 	c4 := pb.NewVirtioBlkServiceClient(conn)
+	log.Printf("Testing NewVirtioBlkServiceClient")
 	rv1, err := c4.VirtioBlkCreate(ctx, &pb.VirtioBlkCreateRequest{Controller: &pb.VirtioBlk{Name: "VirtioBlk8", Bdev:"Malloc1"}})
 	if err != nil {
 		log.Fatalf("could not create VirtioBlk Controller: %v", err)
@@ -144,6 +148,7 @@ func do_frontend(conn grpc.ClientConnInterface, ctx context.Context) {
 
 	// VirtioScsiController
 	c5 := pb.NewVirtioScsiControllerServiceClient(conn)
+	log.Printf("Testing NewVirtioScsiControllerServiceClient")
 	rss1, err := c5.VirtioScsiControllerCreate(ctx, &pb.VirtioScsiControllerCreateRequest{Controller: &pb.VirtioScsiController{Name: "OPI-VirtioScsi8"}})
 	if err != nil {
 		log.Fatalf("could not create VirtioScsi subsystem: %v", err)
@@ -172,6 +177,7 @@ func do_frontend(conn grpc.ClientConnInterface, ctx context.Context) {
 
 	// VirtioScsiLun
 	c6 := pb.NewVirtioScsiLunServiceClient(conn)
+	log.Printf("Testing NewVirtioScsiLunServiceClient")
 	rl1, err := c6.VirtioScsiLunCreate(ctx, &pb.VirtioScsiLunCreateRequest{Lun: &pb.VirtioScsiLun{ControllerId: 8, Bdev: "Malloc1"}})
 	if err != nil {
 		log.Fatalf("could not create VirtioScsi subsystem: %v", err)

--- a/storage/server/backend.go
+++ b/storage/server/backend.go
@@ -30,6 +30,7 @@ func (s *server) NVMfRemoteControllerConnect(ctx context.Context, in *pb.NVMfRem
 	err := call("bdev_get_bdevs", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (len(result) != 1) {

--- a/storage/server/backend.go
+++ b/storage/server/backend.go
@@ -29,7 +29,7 @@ func (s *server) NVMfRemoteControllerConnect(ctx context.Context, in *pb.NVMfRem
 	// TODO: bdev_nvme_attach_controller -b Nvme0 -t RDMA -a 192.168.100.1 -f IPv4 -s 4420 -n nqn.2016-06.io.spdk:cnode1
 	err := call("bdev_get_bdevs", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)

--- a/storage/server/frontend.go
+++ b/storage/server/frontend.go
@@ -30,7 +30,7 @@ func (s *server) NVMeSubsystemCreate(ctx context.Context, in *pb.NVMeSubsystemCr
 	var result string
 	err := call("bdev_malloc_create", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -47,7 +47,7 @@ func (s *server) NVMeSubsystemDelete(ctx context.Context, in *pb.NVMeSubsystemDe
 	var result bool
 	err := call("bdev_malloc_delete", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -67,7 +67,7 @@ func (s *server) NVMeSubsystemUpdate(ctx context.Context, in *pb.NVMeSubsystemUp
 	var result1 bool
 	err1 := call("bdev_malloc_delete", &params1, &result1)
 	if err1 != nil {
-		log.Printf("error: %v\n", err1)
+		log.Printf("error: %v", err1)
 		return nil, err1
 	}
 	log.Printf("Received from SPDK: %v", result1)
@@ -88,7 +88,7 @@ func (s *server) NVMeSubsystemUpdate(ctx context.Context, in *pb.NVMeSubsystemUp
 	var result2 string
 	err2 := call("bdev_malloc_create", &params2, &result2)
 	if err2 != nil {
-		log.Printf("error: %v\n", err2)
+		log.Printf("error: %v", err2)
 		return nil, err2
 	}
 	log.Printf("Received from SPDK: %v", result2)
@@ -105,7 +105,7 @@ func (s *server) NVMeSubsystemList(ctx context.Context, in *pb.NVMeSubsystemList
 	}
 	err := call("bdev_get_bdevs", nil, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -132,7 +132,7 @@ func (s *server) NVMeSubsystemGet(ctx context.Context, in *pb.NVMeSubsystemGetRe
 	}
 	err := call("bdev_get_bdevs", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -168,7 +168,7 @@ func (s *server) NVMeSubsystemStats(ctx context.Context, in *pb.NVMeSubsystemSta
 	}
 	err := call("bdev_get_iostat", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -258,7 +258,7 @@ func (s *server) VirtioBlkCreate(ctx context.Context, in *pb.VirtioBlkCreateRequ
 	var result bool
 	err := call("vhost_create_blk_controller", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -278,7 +278,7 @@ func (s *server) VirtioBlkDelete(ctx context.Context, in *pb.VirtioBlkDeleteRequ
 	var result bool
 	err := call("vhost_delete_controller", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -304,7 +304,7 @@ func (s *server) VirtioBlkList(ctx context.Context, in *pb.VirtioBlkListRequest)
 	}
 	err := call("vhost_get_controllers", nil, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -333,7 +333,7 @@ func (s *server) VirtioBlkGet(ctx context.Context, in *pb.VirtioBlkGetRequest) (
 	}
 	err := call("vhost_get_controllers", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -360,7 +360,7 @@ func (s *server) VirtioScsiControllerCreate(ctx context.Context, in *pb.VirtioSc
 	var result bool
 	err := call("vhost_create_scsi_controller", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -380,7 +380,7 @@ func (s *server) VirtioScsiControllerDelete(ctx context.Context, in *pb.VirtioSc
 	var result bool
 	err := call("vhost_delete_controller", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -406,7 +406,7 @@ func (s *server) VirtioScsiControllerList(ctx context.Context, in *pb.VirtioScsi
 	}
 	err := call("vhost_get_controllers", nil, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -434,7 +434,7 @@ func (s *server) VirtioScsiControllerGet(ctx context.Context, in *pb.VirtioScsiC
 	}
 	err := call("vhost_get_controllers", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -465,7 +465,7 @@ func (s *server) VirtioScsiLunCreate(ctx context.Context, in *pb.VirtioScsiLunCr
 	var result int
 	err := call("vhost_scsi_controller_add_target", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -484,7 +484,7 @@ func (s *server) VirtioScsiLunDelete(ctx context.Context, in *pb.VirtioScsiLunDe
 	var result bool
 	err := call("vhost_scsi_controller_remove_target", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -510,7 +510,7 @@ func (s *server) VirtioScsiLunList(ctx context.Context, in *pb.VirtioScsiLunList
 	}
 	err := call("vhost_get_controllers", nil, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
@@ -538,7 +538,7 @@ func (s *server) VirtioScsiLunGet(ctx context.Context, in *pb.VirtioScsiLunGetRe
 	}
 	err := call("vhost_get_controllers", &params, &result)
 	if err != nil {
-		log.Printf("error: %v\n", err)
+		log.Printf("error: %v", err)
 		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)

--- a/storage/server/frontend.go
+++ b/storage/server/frontend.go
@@ -273,7 +273,7 @@ func (s *server) VirtioBlkDelete(ctx context.Context, in *pb.VirtioBlkDeleteRequ
 	params := struct {
 		Name        string `json:"ctrlr"`
 	}{
-		Name:       fmt.Sprint("VhostNvme", in.GetControllerId()),
+		Name:       fmt.Sprint("VirtioBlk", in.GetControllerId()),
 	}
 	var result bool
 	err := call("vhost_delete_controller", &params, &result)

--- a/storage/server/frontend.go
+++ b/storage/server/frontend.go
@@ -31,6 +31,7 @@ func (s *server) NVMeSubsystemCreate(ctx context.Context, in *pb.NVMeSubsystemCr
 	err := call("bdev_malloc_create", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	return &pb.NVMeSubsystemCreateResponse{}, nil
@@ -47,6 +48,7 @@ func (s *server) NVMeSubsystemDelete(ctx context.Context, in *pb.NVMeSubsystemDe
 	err := call("bdev_malloc_delete", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (!result) {
@@ -66,6 +68,7 @@ func (s *server) NVMeSubsystemUpdate(ctx context.Context, in *pb.NVMeSubsystemUp
 	err1 := call("bdev_malloc_delete", &params1, &result1)
 	if err1 != nil {
 		log.Printf("error: %v\n", err1)
+		return nil, err1
 	}
 	log.Printf("Received from SPDK: %v", result1)
 	if (!result1) {
@@ -86,6 +89,7 @@ func (s *server) NVMeSubsystemUpdate(ctx context.Context, in *pb.NVMeSubsystemUp
 	err2 := call("bdev_malloc_create", &params2, &result2)
 	if err2 != nil {
 		log.Printf("error: %v\n", err2)
+		return nil, err2
 	}
 	log.Printf("Received from SPDK: %v", result2)
 	return &pb.NVMeSubsystemUpdateResponse{}, nil
@@ -102,6 +106,7 @@ func (s *server) NVMeSubsystemList(ctx context.Context, in *pb.NVMeSubsystemList
 	err := call("bdev_get_bdevs", nil, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	Blobarray := make([]*pb.NVMeSubsystem, len(result))
@@ -128,6 +133,7 @@ func (s *server) NVMeSubsystemGet(ctx context.Context, in *pb.NVMeSubsystemGetRe
 	err := call("bdev_get_bdevs", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (len(result) != 1) {
@@ -163,6 +169,7 @@ func (s *server) NVMeSubsystemStats(ctx context.Context, in *pb.NVMeSubsystemSta
 	err := call("bdev_get_iostat", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (len(result.Bdevs) != 1) {
@@ -252,6 +259,7 @@ func (s *server) VirtioBlkCreate(ctx context.Context, in *pb.VirtioBlkCreateRequ
 	err := call("vhost_create_blk_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (!result) {
@@ -271,6 +279,7 @@ func (s *server) VirtioBlkDelete(ctx context.Context, in *pb.VirtioBlkDeleteRequ
 	err := call("vhost_delete_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (!result) {
@@ -296,6 +305,7 @@ func (s *server) VirtioBlkList(ctx context.Context, in *pb.VirtioBlkListRequest)
 	err := call("vhost_get_controllers", nil, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	Blobarray := make([]*pb.VirtioBlk, len(result))
@@ -324,6 +334,7 @@ func (s *server) VirtioBlkGet(ctx context.Context, in *pb.VirtioBlkGetRequest) (
 	err := call("vhost_get_controllers", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (len(result) != 1) {
@@ -350,6 +361,7 @@ func (s *server) VirtioScsiControllerCreate(ctx context.Context, in *pb.VirtioSc
 	err := call("vhost_create_scsi_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (!result) {
@@ -369,6 +381,7 @@ func (s *server) VirtioScsiControllerDelete(ctx context.Context, in *pb.VirtioSc
 	err := call("vhost_delete_controller", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (!result) {
@@ -394,6 +407,7 @@ func (s *server) VirtioScsiControllerList(ctx context.Context, in *pb.VirtioScsi
 	err := call("vhost_get_controllers", nil, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	Blobarray := make([]*pb.VirtioScsiController, len(result))
@@ -421,6 +435,7 @@ func (s *server) VirtioScsiControllerGet(ctx context.Context, in *pb.VirtioScsiC
 	err := call("vhost_get_controllers", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (len(result) != 1) {
@@ -451,6 +466,7 @@ func (s *server) VirtioScsiLunCreate(ctx context.Context, in *pb.VirtioScsiLunCr
 	err := call("vhost_scsi_controller_add_target", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	return &pb.VirtioScsiLunCreateResponse{}, nil
@@ -469,6 +485,7 @@ func (s *server) VirtioScsiLunDelete(ctx context.Context, in *pb.VirtioScsiLunDe
 	err := call("vhost_scsi_controller_remove_target", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (!result) {
@@ -494,6 +511,7 @@ func (s *server) VirtioScsiLunList(ctx context.Context, in *pb.VirtioScsiLunList
 	err := call("vhost_get_controllers", nil, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	Blobarray := make([]*pb.VirtioScsiLun, len(result))
@@ -521,6 +539,7 @@ func (s *server) VirtioScsiLunGet(ctx context.Context, in *pb.VirtioScsiLunGetRe
 	err := call("vhost_get_controllers", &params, &result)
 	if err != nil {
 		log.Printf("error: %v\n", err)
+		return nil, err
 	}
 	log.Printf("Received from SPDK: %v", result)
 	if (len(result) != 1) {


### PR DESCRIPTION
Fixes #367

tested like this
```
 $ docker run --network=storage_opi --rm -it namely/grpc-cli call opi-spdk-server:50051 NVMeSubsystemGet ""
connecting to opi-spdk-server:50051
Rpc failed with status code 2, error message: bdev_get_bdevs: json response error: No such device
```
server is no longer crashing , see:
```
opi-spdk-server_1  | 2022/09/21 20:12:01 NVMeSubsystemGet: Received from client:
opi-spdk-server_1  | 2022/09/21 20:12:01 Sending to SPDK: {"jsonrpc":"2.0","id":24,"method":"bdev_get_bdevs","params":{"name":"OpiMalloc"}}
opi-spdk-server_1  | 2022/09/21 20:12:01 Received from SPDK: {24 {-19 No such device} 0xc0003ac348}
opi-spdk-server_1  | 2022/09/21 20:12:01 error: bdev_get_bdevs: json response error: No such device
```

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
