### PR TITLE
Remove old spdk avx512 workaround

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -50,14 +50,6 @@ the spdk-target image.
 ./scripts/integration.sh start
 ```
 
-If you try to run on a platform that does not support every extended instruction
-that SPDK supports, the pulled spdk-target image will not function.  To work
-around this, set the `BUILD_SPDK` variable before starting:
-
-```bash
-BUILD_SPDK=1 ./scripts/integration.sh start
-```
-
 ### Start - Red Hat
 
 **Note** Root-less podman is not supported.  So run the integration script as

--- a/integration/scripts/integration.sh
+++ b/integration/scripts/integration.sh
@@ -27,10 +27,6 @@ start_containers() {
     docker-compose down
     docker network prune --force
     docker-compose pull
-    # Workaround for running on servers without AVX512
-    if [ -n "${BUILD_SPDK:-}" ]; then
-        docker-compose build spdk-target
-    fi
     docker-compose up -d
 }
 


### PR DESCRIPTION
Now that the spdk image uses a target to avoid requiring avx512, the workaround is no longer needed.

Signed-off-by: Steven Royer <sroyer@redhat.com>