### PR TITLE
integration: fix /var/tmp mount in xpu

### DIFF
--- a/integration/docker-compose.xpu.yml
+++ b/integration/docker-compose.xpu.yml
@@ -63,7 +63,7 @@ services:
       - /dev/hugepages:/dev/hugepages
       - /dev/shm:/dev/shm
       - /proc:/proc
-      - /var/tmp/
+      - /var/tmp:/var/tmp
     privileged: true
     network_mode: service:xpu-cpu-ssh
     working_dir: /usr/libexec/spdk/scripts


### PR DESCRIPTION
From: integration_xpu-spdk-web_1
Error details: Invalid or non-existing address: '/var/tmp/spdk.sock'

Signed-off-by: Steven Royer <sroyer@redhat.com>