### PR TITLE
integration: fix web healthcheck

### DIFF
--- a/integration/docker-compose.pxe.yml
+++ b/integration/docker-compose.pxe.yml
@@ -35,7 +35,14 @@ services:
       xpu-cpu:
         ipv4_address: 10.127.127.16
     healthcheck:
-      test: curl --silent --fail http://localhost:8082 || exit 1
+      test: |
+        python -c "
+        from urllib.request import urlopen
+        try:
+            urlopen('http://localhost:8082').read()
+            exit(0)
+        except Exception as e:
+            exit(1)"
     command: python3 -m http.server 8082
 
   bootstrap:


### PR DESCRIPTION
When changing the base image from a full python image to a slim python image, the curl based healthcheck no longer worked.  Replace it with a simple inline python program.

Fixes #471 

Signed-off-by: Steven Royer <sroyer@redhat.com>