### PR TITLE
[docker] pull images by tag AND digest instead of labels

### DIFF
--- a/integration/docker-compose.pxe.yml
+++ b/integration/docker-compose.pxe.yml
@@ -4,7 +4,7 @@ version: '3.7'
 services:
 
   dhcp:
-    image: ghcr.io/opiproject/opi-dhcp-server@sha256:16b35123f7f6dd1d5a49a81227ec039bbd259353a55471255eaefad1574dbe6e
+    image: ghcr.io/opiproject/opi-dhcp-server:main@sha256:16b35123f7f6dd1d5a49a81227ec039bbd259353a55471255eaefad1574dbe6e
     environment:
       NODE_IP_SUBNET: 10.127.127.0
       NODE_IP_NETMASK: 255.255.255.0
@@ -28,7 +28,7 @@ services:
     command: --script broadcast-dhcp-discover
 
   web:
-    image: ghcr.io/opiproject/opi-web@sha256:47fac9022399fef5d951525e6b2ed86ab20e56ae8cc06ca7a3ce738f1c191e3a
+    image: ghcr.io/opiproject/opi-web:main@sha256:47fac9022399fef5d951525e6b2ed86ab20e56ae8cc06ca7a3ce738f1c191e3a
     ports:
       - 8082:8082
     networks:
@@ -39,7 +39,7 @@ services:
     command: python3 -m http.server 8082
 
   bootstrap:
-    image: ghcr.io/opiproject/opi-sztp-server@sha256:1bab6b91e9835fc9bdfdb3b35ac33a51f4414c6c3015180edfcdeb312bed1e1d
+    image: ghcr.io/opiproject/opi-sztp-server:main@sha256:1bab6b91e9835fc9bdfdb3b35ac33a51f4414c6c3015180edfcdeb312bed1e1d
     environment:
       SZTPD_INIT_PORT: 1080
       SZTPD_SBI_PORT: 9090
@@ -56,7 +56,7 @@ services:
       test: ["CMD-SHELL", "curl --fail -H Accept:application/yang-data+json http://127.0.0.1:$$SZTPD_INIT_PORT/.well-known/host-meta || exit 1"]
 
   redirecter:
-    image: ghcr.io/opiproject/opi-sztp-server@sha256:1bab6b91e9835fc9bdfdb3b35ac33a51f4414c6c3015180edfcdeb312bed1e1d
+    image: ghcr.io/opiproject/opi-sztp-server:main@sha256:1bab6b91e9835fc9bdfdb3b35ac33a51f4414c6c3015180edfcdeb312bed1e1d
     environment:
       SZTPD_INIT_PORT: 1080
       SZTPD_SBI_PORT: 8080
@@ -73,7 +73,7 @@ services:
       test: ["CMD-SHELL", "curl --fail -H Accept:application/yang-data+json http://127.0.0.1:$$SZTPD_INIT_PORT/.well-known/host-meta || exit 1"]
 
   dhclient:
-    image: ghcr.io/opiproject/opi-dhcp-client@sha256:a78214c2bbb8815496e922b329344cba07bce3c2d23041fc7f8ea809a05f75f5
+    image: ghcr.io/opiproject/opi-dhcp-client:main@sha256:a78214c2bbb8815496e922b329344cba07bce3c2d23041fc7f8ea809a05f75f5
     cap_add:
       - CAP_NET_RAW
     volumes:
@@ -82,7 +82,7 @@ services:
     command: dhclient -d -v
 
   agent:
-    image: ghcr.io/opiproject/opi-sztp-agent@sha256:a6995685661cfdb2e7e547205c2f8810a1f5602eb1cca0830677a0271882262d
+    image: ghcr.io/opiproject/opi-sztp-agent:main@sha256:a6995685661cfdb2e7e547205c2f8810a1f5602eb1cca0830677a0271882262d
     depends_on:
       bootstrap:
         condition: service_healthy

--- a/integration/docker-compose.spdk.yml
+++ b/integration/docker-compose.spdk.yml
@@ -4,7 +4,7 @@ version: "3.7"
 services:
 
   spdk-target:
-    image: ghcr.io/opiproject/opi-storage-spdk@sha256:0e8201cc03ec71bcd53fd10e6e02a4224a605000e7b43e35f64810e9bbaf10a1
+    image: ghcr.io/opiproject/opi-storage-spdk:main@sha256:0e8201cc03ec71bcd53fd10e6e02a4224a605000e7b43e35f64810e9bbaf10a1
     volumes:
       - /dev/hugepages:/dev/hugepages
       - /dev/shm:/dev/shm
@@ -39,7 +39,7 @@ services:
       timeout: 10s
 
   spdk-target-web:
-    image: ghcr.io/opiproject/opi-storage-spdk@sha256:0e8201cc03ec71bcd53fd10e6e02a4224a605000e7b43e35f64810e9bbaf10a1
+    image: ghcr.io/opiproject/opi-storage-spdk:main@sha256:0e8201cc03ec71bcd53fd10e6e02a4224a605000e7b43e35f64810e9bbaf10a1
     volumes_from:
       - spdk-target:rw
     ports:

--- a/integration/docker-compose.xpu.yml
+++ b/integration/docker-compose.xpu.yml
@@ -58,7 +58,7 @@ services:
     privileged: true
 
   xpu-spdk:
-    image: ghcr.io/opiproject/opi-storage-spdk@sha256:0e8201cc03ec71bcd53fd10e6e02a4224a605000e7b43e35f64810e9bbaf10a1
+    image: ghcr.io/opiproject/opi-storage-spdk:main@sha256:0e8201cc03ec71bcd53fd10e6e02a4224a605000e7b43e35f64810e9bbaf10a1
     volumes:
       - /dev/hugepages:/dev/hugepages
       - /dev/shm:/dev/shm
@@ -87,7 +87,7 @@ services:
       timeout: 10s
 
   xpu-spdk-web:
-    image: ghcr.io/opiproject/opi-storage-spdk@sha256:0e8201cc03ec71bcd53fd10e6e02a4224a605000e7b43e35f64810e9bbaf10a1
+    image: ghcr.io/opiproject/opi-storage-spdk:main@sha256:0e8201cc03ec71bcd53fd10e6e02a4224a605000e7b43e35f64810e9bbaf10a1
     volumes_from:
       - xpu-spdk:rw
     network_mode: service:xpu-cpu-ssh


### PR DESCRIPTION
Renovate bot needs both tag and digest to work properly
Investigated renovate log/console and saw errors
This is fixing 86329b5012e27a56411ce8199ec13bec30de9214

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
