### PR TITLE
enables dhcp on management interface

### DIFF
--- a/lab/hardware/A100G/arista.config
+++ b/lab/hardware/A100G/arista.config
@@ -1,9 +1,12 @@
 ! Command: show running-config
-! device: localhost (DCS-7280CR-48, EOS-4.20.10M)
+! device: A100G (DCS-7280CR-48, EOS-4.20.10M)
 !
 ! boot system flash:/EOS-4.20.10.M.swi
 !
 transceiver qsfp default-mode 4x10G
+!
+hostname A100G
+ip name-server vrf default 8.8.8.8
 !
 spanning-tree mode mstp
 !
@@ -106,6 +109,7 @@ interface Ethernet46/1
 interface Ethernet47/1
 !
 interface Ethernet48/1
+   shutdown
 !
 interface Ethernet49/1
 !
@@ -172,9 +176,8 @@ interface Ethernet56/3
 interface Ethernet56/4
 !
 interface Management1
-   ip address 172.22.0.250/16
-!
-ip route 0.0.0.0/0 Management1 172.22.0.1
+   ip address dhcp
+   dhcp client accept default-route
 !
 no ip routing
 !


### PR DESCRIPTION
- device name
- dhcp on mgmt
- shuts down 100G interface to ToR (was creating problems, test traffic was reaching the tor)