### PR TITLE
[th/opidemo-marvell-pt1] extend opilab demo script for Marvell DPU

### DIFF
--- a/demos/Secure-AI-inferencing-NGINX-IPU/demo/README.md
+++ b/demos/Secure-AI-inferencing-NGINX-IPU/demo/README.md
@@ -84,10 +84,10 @@ can run for example
 
 - `oc --kubeconfig=/tmp/kubeconfig.ocpcluster get node`
 
-- `oc --kubeconfig=/tmp/kubeconfig.microshift get node`
+- `oc --kubeconfig=/tmp/kubeconfig.microshift-ipu get node`
 
 Alternatively, if you wish, you can also run `./demos.sh oc_ocp ARGS...` and
-`./demo.sh oc_msh ARGS...`. That is the same as calling the `oc` commands with
+`./demo.sh oc_ipu ARGS...`. That is the same as calling the `oc` commands with
 the right kubeconfig. The `oc` command line tool allows you to investigate the
 cluster.
 
@@ -123,7 +123,7 @@ response is returned. Finally, the script prints the classification result
 of the images.
 
 See the NGINX configuration with the upstream pods via
-`./demo.sh oc_msh -n openshift-dpu-operator exec -ti pod/nginx -- cat /etc/nginx/conf.d/91-upstream.conf`.
+`./demo.sh oc_ipu -n openshift-dpu-operator exec -ti pod/nginx -- cat /etc/nginx/conf.d/91-upstream.conf`.
 
 ### Investigate the Demo Setup
 
@@ -133,7 +133,7 @@ Now we can look at the system. Try some of the example commands.
 
     ```bash
     ./demo.sh oc_ocp -n openshift-dpu-operator get all
-    ./demo.sh oc_msh -n openshift-dpu-operator get all
+    ./demo.sh oc_ipu -n openshift-dpu-operator get all
     ```
 
 1. Inspect the AI Inferencing Pods on the host
@@ -147,8 +147,8 @@ Now we can look at the system. Try some of the example commands.
 1. Inspect the NGINX loadbalancer Pod on the IPU
 
     ```bash
-    ./demo.sh oc_msh -n openshift-dpu-operator get pod/nginx
-    ./demo.sh oc_msh -n openshift-dpu-operator exec -ti pod/nginx -- bash
+    ./demo.sh oc_ipu -n openshift-dpu-operator get pod/nginx
+    ./demo.sh oc_ipu -n openshift-dpu-operator exec -ti pod/nginx -- bash
     ```
 
 1. Check IP configuration and traffic
@@ -157,18 +157,18 @@ Now we can look at the system. Try some of the example commands.
     `ping` and `tcpdump` to investigate what is happening.
 
     Either start first an interactive shell via
-    `./demo.sh oc_msh -n openshift-dpu-operator exec -ti pod/nginx -- bash`,
+    `./demo.sh oc_ipu -n openshift-dpu-operator exec -ti pod/nginx -- bash`,
     or run as separate commands:
 
     ```bash
-    ./demo.sh oc_msh -n openshift-dpu-operator exec -ti pod/nginx -- ps aux
+    ./demo.sh oc_ipu -n openshift-dpu-operator exec -ti pod/nginx -- ps aux
 
-    ./demo.sh oc_msh -n openshift-dpu-operator exec -ti pod/nginx -- ip addr
+    ./demo.sh oc_ipu -n openshift-dpu-operator exec -ti pod/nginx -- ip addr
 
     POD_IP=$(./demo.sh pod_detect_net1_ip resnet50-model-server-2)
-    ./demo.sh oc_msh -n openshift-dpu-operator exec -ti pod/nginx -- ping -c 3 "$POD_IP"
+    ./demo.sh oc_ipu -n openshift-dpu-operator exec -ti pod/nginx -- ping -c 3 "$POD_IP"
 
-    ./demo.sh oc_msh -n openshift-dpu-operator exec -ti pod/nginx -- tcpdump -ni net2
+    ./demo.sh oc_ipu -n openshift-dpu-operator exec -ti pod/nginx -- tcpdump -ni net2
     ```
 
 ### Run the Demo "inspect" Example
@@ -199,7 +199,7 @@ at the `pod_create()` function.
 
 Likewise, to create the NGINX network function on the IPU side, we create a
 `ServiceFunctionChain` CR. You can see how that is done in the `sfc_create()`
-function. You can also see this service function chain via `./demo.sh oc_msh
+function. You can also see this service function chain via `./demo.sh oc_ipu
 get sfc -A`. Based on that custom resource will the DPU operator create the
 NGINX pod.
 

--- a/demos/Secure-AI-inferencing-NGINX-IPU/demo/demo.sh
+++ b/demos/Secure-AI-inferencing-NGINX-IPU/demo/demo.sh
@@ -391,10 +391,12 @@ sfc_create() {
 
 sfc_wait() {
     _echo_p "Wait for SFC pod with nginx to be ready"
-    if ! oc_msh -n openshift-dpu-operator get pod/nginx &>/dev/null ; then
-        timeout 60 bash -c 'while ! oc_msh -n openshift-dpu-operator get pod/nginx ; do sleep 1 ; done'
-    fi
-    oc_msh -n openshift-dpu-operator wait --for=condition=Ready pod/nginx --timeout=15m
+    _retry_with_timeout "60" \
+        oc_msh -n openshift-dpu-operator get pod/nginx &>/dev/null \
+        || return 1
+    oc_msh -n openshift-dpu-operator wait --for=condition=Ready pod/nginx --timeout=15m \
+        || return 1
+    return 0
 }
 
 sfc_delete() {

--- a/demos/Secure-AI-inferencing-NGINX-IPU/demo/demo.sh
+++ b/demos/Secure-AI-inferencing-NGINX-IPU/demo/demo.sh
@@ -27,16 +27,23 @@ HOST_DPU_IPU_EXTERN="${HOST_DPU_IPU_EXTERN:-172.22.1.104}" # dh4-acc
 # The IPU's IMC
 HOST_BMC_IPU="${HOST_BMC_IPU:-172.22.4.4}" # dh4-imc
 
+# The MVL DPU
+HOST_DPU_MVL="${HOST_DPU_MVL:-172.16.3.13}" # dh3-acc
+
+# The MVL DPU (as reachable from localhost)
+HOST_DPU_MVL_EXTERN="${HOST_DPU_MVL_EXTERN:-172.22.1.103}" # dh3-acc
+
 # The public facing IP address inside the nginx pod on the IPU.
 HOST_NGINX_IPU="${HOST_NGINX_IPU:-172.16.3.200}"
 
 # Management host
 HOST_MGMT="${HOST_MGMT:-172.22.0.1}" # mgmt
 
-NUM_PODS="${NUM_PODS:-3}"
+# Whether this script is *not* used with the OPI lab but another cluster. In that case,
+# the user will set environment variables to make the script usable.
+EXTERNAL_CLUSTER="${EXTERNAL_CLUSTER:-0}"
 
-KC_OCP="${KC_OCP:-}"
-KC_IPU="${KC_IPU:-}"
+NUM_PODS="${NUM_PODS:-3}"
 
 ###############################################################################
 
@@ -45,10 +52,15 @@ if [ -z "$KC_OCP" ] ; then
     if [ ! -f "$KC_OCP" ] && [ -f "/tmp/kubeconfig.ocpcluster"  ] ; then KC_OCP="/tmp/kubeconfig.ocpcluster"  ; fi
     if [ ! -f "$KC_OCP" ] && [ -f "/root/kubeconfig.ocpcluster" ] ; then KC_OCP="/root/kubeconfig.ocpcluster" ; fi
 fi
-if [ -z "$KC_IPU" ] ; then
+if [ -z "${KC_IPU+x}" ] ; then
     KC_IPU="$PWD/kubeconfig.microshift-ipu"
     if [ ! -f "$KC_IPU" ] && [ -f "/tmp/kubeconfig.microshift-ipu"  ] ; then KC_IPU="/tmp/kubeconfig.microshift-ipu"  ; fi
     if [ ! -f "$KC_IPU" ] && [ -f "/root/kubeconfig.microshift-ipu" ] ; then KC_IPU="/root/kubeconfig.microshift-ipu" ; fi
+fi
+if [ -z "${KC_MVL+x}" ] ; then
+    KC_MVL="$PWD/kubeconfig.microshift-ipu"
+    if [ ! -f "$KC_MVL" ] && [ -f "/tmp/kubeconfig.microshift-ipu"  ] ; then KC_MVL="/tmp/kubeconfig.microshift-ipu"  ; fi
+    if [ ! -f "$KC_MVL" ] && [ -f "/root/kubeconfig.microshift-ipu" ] ; then KC_MVL="/root/kubeconfig.microshift-ipu" ; fi
 fi
 
 POD_NAME_BASE="resnet50-model-server"
@@ -147,12 +159,14 @@ _retry_with_timeout() {
     done
 }
 
-usage() {
+_usage() {
+    local scriptname="$1"
+    local scriptname0="$2"
     local commands
 
-    mapfile -t commands < <(sed -n '/^    case "''$''cmd" in/,/    esac$/ s/^        \([a-zA-Z_0-9]\+\).*/\1/p' "$SCRIPTNAME")
+    mapfile -t commands < <(sed -n '/^    case "''$''main_cmd" in/,/    esac$/ s/^        \([a-zA-Z_0-9]\+\).*/\1/p' "$scriptname")
 
-    _echo "Usage $C_GREEN$SCRIPTNAME$C_RESET COMMAND..."
+    _echo "Usage $C_GREEN$scriptname$C_RESET COMMAND..."
     _echo
     _echo "Inspect the script or run with \`bash -x\` to see what the shell script does."
     _echo "You may source the script and call the shell functions directly."
@@ -160,6 +174,7 @@ usage() {
     _echo "Uses:"
     _echo "  export KC_OCP=$C_BLUE$(printf '%q' "$KC_OCP")$C_RESET"
     _echo "  export KC_IPU=$C_BLUE$(printf '%q' "$KC_IPU")$C_RESET"
+    _echo "  export KC_MVL=$C_BLUE$(printf '%q' "$KC_MVL")$C_RESET"
     _echo
 
     # Parse the shell script itself, to get out the available commands and
@@ -213,7 +228,7 @@ usage() {
             print(f"  {c_green}{cmd}{c_reset}{synopsis}")
             print("".join(f"    {s}\n" for s in doc), end="")
     ' \
-        "$SCRIPTNAME" \
+        "$scriptname" \
         "$C_YELLOW" \
         "$C_GREEN" \
         "$C_RESET" \
@@ -222,32 +237,52 @@ usage() {
     _echo
     _echo "Setup localhost:"
     _echo " - # connect to VPN (\`openconnect --protocol=f5 vpn.opiproject-lab.org\`)"
-    _echo " - $(printf '%q' "$SCRIPTNAME0") ssh_copy_id \$SSHKEY"
-    _echo " - $(printf '%q' "$SCRIPTNAME0") etc_hosts update"
-    _echo " - $(printf '%q' "$SCRIPTNAME0") kubeconfigs /tmp"
-    _echo " - $(printf '%q' "$SCRIPTNAME0") info"
+    _echo " - $(printf '%q' "$scriptname0") ssh_copy_id \$SSHKEY"
+    _echo " - $(printf '%q' "$scriptname0") etc_hosts update"
+    _echo " - $(printf '%q' "$scriptname0") kubeconfigs /tmp"
+    _echo " - $(printf '%q' "$scriptname0") info"
 }
 
-is_prov_host() {
+usage() {
+    _usage "$SCRIPTNAME" "$SCRIPTNAME0"
+}
+
+check_no_external_cluster() {
+    if [ "$EXTERNAL_CLUSTER" = 1 ] ; then
+        die "Cannot call $main_cmd with external cluster"
+    fi
+}
+
+host_has_ip() {
     # Check whether the current host is the provisioning host.
+    local ip="$1"
     local h
     local is=1
 
     for h in $(hostname -I) ; do
-        if [ "$h" = "$HOST_PROV" ] ; then
+        if [ "$h" = "$ip" ] ; then
             is=0
             break
         fi
     done
 
-    # Update the function itself with a memoized value. Let's only
-    # detect once.
-    eval "is_prov_host() { return $is ; }"
-
     return $is
 }
 
+is_prov_host() {
+    # Check whether the current host is the provisioning host.
+    local rc=0
+
+    host_has_ip "$HOST_PROV" || rc=1
+
+    # Update the function itself with a memoized value. Let's only
+    # detect once.
+    eval "is_prov_host() { return $rc ; }"
+    return $rc
+}
+
 get_podnames() {
+    _EXEC_NOTTY=1 \
     oc_ocp -n default get pods \
         -l app="$POD_NAME_BASE-service" \
         -o custom-columns=:metadata.name --no-headers \
@@ -270,22 +305,84 @@ get_podname() {
     esac
 }
 
+_detect_kind() {
+    case "$1" in
+        ""|a|auto)
+            [ -n "$KC_IPU" ] || [ -n "$KC_MVL" ] || die "no KC_IPU or KC_MVL to detect kind"
+            [ -z "$KC_IPU" ] || { _echo 'ipu' ; return 0 ; }
+            [ -z "$KC_MVL" ] || { _echo 'mvl' ; return 0 ; }
+
+            local oc_kind
+            local rc
+            local out
+            for oc_kind in 'ipu' 'mvl' ; do
+                if [ -n "$(_oc get nodes -l dpu=true --no-headers 2>/dev/null ; true)" ] ; then
+                    _echo "$oc_kind"
+                    return 0
+                fi
+            done
+            # default to "ipu"
+            _echo 'ipu'
+            ;;
+        i|ipu)
+            [ -n "$KC_IPU" ] || die "no KC_IPU for IPU kind"
+            _echo 'ipu'
+            ;;
+        m|mvl|mrvl|marvell)
+            [ -n "$KC_MVL" ] || die "no KC_MVL for marvell kind"
+            _echo 'mvl'
+            ;;
+        *)
+            die "invalid kind $(_echo "$1")"
+            ;;
+    esac
+}
+
+_oc() {
+    "oc_$oc_kind" "$@"
+}
+
 # 2:check cluster:5
 # OC_ARGS...
 # Call `oc` command for OCP cluster "opicluster".
 oc_ocp() {
-    oc --kubeconfig="$KC_OCP" "$@"
+    [ -n "$KC_OCP" ] || die "No KC_OCP to access OCP cluster"
+    if [ "$EXTERNAL_CLUSTER" = 1 ] ; then
+        _EXEC_SILENT=1 \
+        _exec prov oc --kubeconfig="$KC_OCP" "$@"
+    else
+        oc --kubeconfig="$KC_OCP" "$@"
+    fi
 }
 
 # 2:check cluster:6
 # OC_ARGS...
-# Call `oc` command for microshift on dh4-acc.
+# Call `oc` command for microshift on the IPU on dh4-acc.
 oc_ipu() {
-    oc --kubeconfig="$KC_IPU" "$@"
+    [ -n "$KC_IPU" ] || die "No KC_IPU to access IPU cluster"
+    if [ "$EXTERNAL_CLUSTER" = 1 ] ; then
+        _EXEC_SILENT=1 \
+        _exec prov oc --kubeconfig="$KC_IPU" "$@"
+    else
+        oc --kubeconfig="$KC_IPU" "$@"
+    fi
+}
+
+# 2:check cluster:7
+# OC_ARGS...
+# Call `oc` command for microshift on Marvell DPU on dh3-acc.
+oc_mvl() {
+    [ -n "$KC_MVL" ] || die "No KC_MVL to access Marvell cluster"
+    if [ "$EXTERNAL_CLUSTER" = 1 ] ; then
+        _EXEC_SILENT=1 \
+        _exec prov oc --kubeconfig="$KC_MVL" "$@"
+    else
+        oc --kubeconfig="$KC_MVL" "$@"
+    fi
 }
 
 oc_nginx_exec() {
-    oc_ipu -n openshift-dpu-operator exec -i pod/nginx -- "$@"
+    _oc -n openshift-dpu-operator exec -i pod/nginx -- "$@"
 }
 
 _oc_node_pattern_filter() {
@@ -411,13 +508,15 @@ wait_ssh() {
 
 sfc_create() {
     _echo_p "Create SFC \"sfc-test\" in openshift-dpu-operator"
-    cat <<'    EOF' | sed 's/^        //' | oc_ipu create -f -
+    cat <<'    EOF' | sed 's/^        //' | _oc create -f -
         apiVersion: config.openshift.io/v1
         kind: ServiceFunctionChain
         metadata:
           name: sfc-test
           namespace: openshift-dpu-operator
         spec:
+          nodeSelector:
+            dpu.config.openshift.io/dpuside: "dpu"
           networkFunctions:
           - name: nginx
             image: nginx
@@ -428,19 +527,19 @@ sfc_create() {
 sfc_wait() {
     _echo_p "Wait for SFC pod with nginx to be ready"
     _retry_with_timeout "60" \
-        oc_ipu -n openshift-dpu-operator get pod/nginx &>/dev/null \
+        _oc -n openshift-dpu-operator get pod/nginx &>/dev/null \
         || return 1
-    oc_ipu -n openshift-dpu-operator wait --for=condition=Ready pod/nginx --timeout=15m \
+    _oc -n openshift-dpu-operator wait --for=condition=Ready pod/nginx --timeout=15m \
         || return 1
     return 0
 }
 
 sfc_delete() {
-    oc_ipu -n openshift-dpu-operator delete ServiceFunctionChain/sfc-test || true
+    _oc -n openshift-dpu-operator delete ServiceFunctionChain/sfc-test || true
 }
 
 sfc_wait_deleted() {
-    oc_ipu -n openshift-dpu-operator wait --for="delete" "pod/nginx" --timeout=15m
+    _oc -n openshift-dpu-operator wait "--for=delete" "pod/nginx" --timeout=15m
 }
 
 pod_deployment_create() {
@@ -467,7 +566,7 @@ pod_deployment_create() {
               securityContext:
                 runAsUser: 0
               nodeSelector:
-                dpu: "true"
+                dpu.config.openshift.io/dpuside: "dpu-host"
               volumes:
                 - name: model-volume
                   emptyDir: {}
@@ -569,7 +668,7 @@ pods_setup() {
         oc_ocp -n default exec -i "pod/$pod_name" -- /bin/bash -c '
             set -x &&
             apt-get update &&
-            apt-get install -y procps iproute2 iputils-ping net-tools tcpdump &&
+            apt-get install -y procps iproute2 iputils-ping net-tools tcpdump ethtool &&
             true
         '
     done
@@ -582,7 +681,7 @@ pod_deployment_delete() {
 
 pods_wait_deleted() {
     _echo_p "Wait for resnet pods to be deleted"
-    oc_ocp -n default wait --for="delete" -l app="$POD_NAME_BASE-service" pod --timeout=15m
+    oc_ocp -n default wait "--for=delete" -l app="$POD_NAME_BASE-service" pod --timeout=15m
 }
 
 nginx_setup_base() {
@@ -646,10 +745,12 @@ nginx_setup_ipaddr() {
     oc_nginx_exec bash -c "
         set -x && \\
         apt-get update && \\
-        apt-get install -y procps iproute2 iputils-ping net-tools tcpdump && \\
+        apt-get install -y procps iproute2 iputils-ping net-tools tcpdump ethtool && \\
+        ethtool -K net1 rx off tx off && \\
+        ethtool -K net2 rx off tx off && \\
         ip addr flush dev net1 && \\
         ip addr flush dev net2 && \\
-        ip addr add 10.56.217.3/24 dev net2 && \\
+        ip addr add 10.56.217.3/24 dev net1 && \\
         ip addr add $HOST_NGINX_IPU/24 dev net2 && \\
         ip addr
     "
@@ -668,6 +769,7 @@ nginx_setup_upstream_ip() {
 
 nginx_setup_upstream() {
     local pod_name
+    local pod_names
     local ip
 
     # Detect and configure the IP addresses of the AI pods as upstream for the
@@ -677,7 +779,9 @@ nginx_setup_upstream() {
     # definition is configured to hand out a certain 10.56.217.0/24 range to
     # the pods.
 
-    while IFS= read -r pod_name ; do
+    mapfile -t pod_names < <(get_podnames)
+
+    for pod_name in "${pod_names[@]}" ; do
         ip="$(pod_detect_net1_ip 180 "$pod_name")" \
             || { _echo_p "${C_RED}ERROR${C_RESET}: Failure to detect IP address in $pod_name"; return 1; }
 
@@ -688,7 +792,7 @@ nginx_setup_upstream() {
 
         _echo_p "Configure pod/nginx with upstream IP address $ip for $pod_name"
         nginx_setup_upstream_ip "$ip"
-    done < <(get_podnames)
+    done
 }
 
 nginx_setup_reload() {
@@ -717,15 +821,16 @@ nginx_wait() {
     wait_ping tgen1 30 "$HOST_NGINX_IPU"
 }
 
-# 2:check cluster:7
+# 2:check cluster:8
 #
 # Reconfigure the nginx pod on dh4-acc. This is a subset of redeploy.
 do_nginx_setup() {
+    local oc_kind='ipu'
     nginx_setup
     nginx_wait
 }
 
-# 2:check cluster:8
+# 2:check cluster:9
 # [POD]
 # Reconfigure the resnet pods in the OCP cluster. This is a subset of redeploy.
 # If no pod is given, all of them are reconfigured.
@@ -734,7 +839,7 @@ do_pods_setup() {
     _OPI_DEMO_PODS_SETUP_POD="$1" pods_setup
 }
 
-# 2:check cluster:9
+# 2:check cluster:10
 # POD
 # Lookup the IP address on the secondary network net1 of the AI pod on the OCP
 # side. This is the upstream IP address for the nginx load balancer.
@@ -745,7 +850,7 @@ do_pod_detect_net1_ip() {
 }
 
 _cmd_nginx_macs() {
-    oc_ipu -n openshift-dpu-operator exec pod/nginx -- bash -c '(ip link show net1; ip link show net2) | sed -n "s/^.*link\/ether \+\([^ ]\+\) \+.*$/\1/p"'
+    _oc -n openshift-dpu-operator exec pod/nginx -- bash -c '(ip link show net1; ip link show net2) | sed -n "s/^.*link\/ether \+\([^ ]\+\) \+.*$/\1/p"'
 }
 
 # Check interface rx/tx statistics on dh4-ipu. Call via `watch`
@@ -877,7 +982,7 @@ _exec() {
         localhost)
             ssh_cmd_tgen1=()
             ;;
-        tgen1)
+        prov|tgen1)
             if [ "${#ssh_cmd_tgen1[@]}" -gt 0 ] ; then
                 args=( "${ssh_cmd_tgen1[@]}" "$args_cmd" )
             fi
@@ -952,6 +1057,9 @@ do_remote() {
     if [ -n "$OPI_DEMO_SLEEP_TIME" ] ; then
         envs+=( "OPI_DEMO_SLEEP_TIME=$OPI_DEMO_SLEEP_TIME" )
     fi
+    if [ "$HOST_PROV" != '172.22.1.100' ] ; then
+        envs+=( "HOST_PROV=$HOST_PROV" )
+    fi
 
     # shellcheck disable=SC2031
     _exec tgen1 \
@@ -1014,25 +1122,42 @@ show_info() {
     oc_ocp -n openshift-dpu-operator get all
     oc_ocp -n default get all
 
-    _echo_p "Information about microshift on dh4 for $KC_IPU"
-    oc_ipu get node
-    oc_ipu -n openshift-dpu-operator get all
-    oc_ipu -n default get all
+    local oc_kind
 
-    pod="$(oc_ipu get pods -A -o name | grep 'vsp-p4' | head -n1)"
-    _echo_p "Show ovs-vsctl inside VSP pod $pod on DPU side"
-    oc_ipu -n openshift-dpu-operator exec -i "$pod" -- /opt/p4/p4-cp-nws/bin/ovs-vsctl show || true
-    oc_ipu -n openshift-dpu-operator exec -i "$pod" -- /opt/p4/p4-cp-nws/bin/p4rt-ctl dump-entries br0 | head -n10 || true
-    _cmd_ipu_statistics
+    for oc_kind in ipu mvl ; do
+        if [ "$oc_kind" = 'ipu' ] ; then
+            _echo_p "Information about microshift on dh4 for $KC_IPU"
+        else
+            _echo_p "Information about microshift on dh3 for $KC_MVL"
+        fi
+        _oc get node
+        _oc -n openshift-dpu-operator get all
+        _oc -n default get all
+
+        if [ "$oc_kind" = 'ipu' ] ; then
+            pod="$(_oc get pods -A -o name | grep 'vsp-p4' | head -n1)"
+            _echo_p "Show ovs-vsctl inside VSP pod $pod on DPU side"
+            _oc -n openshift-dpu-operator exec -i "$pod" -- /opt/p4/p4-cp-nws/bin/ovs-vsctl show || true
+            _oc -n openshift-dpu-operator exec -i "$pod" -- /opt/p4/p4-cp-nws/bin/p4rt-ctl dump-entries br0 | head -n10 || true
+            _cmd_ipu_statistics
+        fi
+    done
 }
 
 cleanup_all() {
     _echo_p "Delete SFC"
-    sfc_delete
+    [ -z "$KC_IPU" ] \
+        || oc_kind=ipu sfc_delete
+    [ -z "$KC_MVL" ] \
+        || oc_kind=mvl sfc_delete
     pod_deployment_delete
 
     _echo_p "Wait for SFC and Pods to be gone"
-    sfc_wait_deleted \
+    [ -z "$KC_IPU" ] \
+        || oc_kind=ipu sfc_wait_deleted \
+        || _echo_p "  Failed"
+    [ -z "$KC_MVL" ] \
+        || oc_kind=mvl sfc_wait_deleted \
         || _echo_p "  Failed"
     pods_wait_deleted \
         || _echo_p "  Failed"
@@ -1333,15 +1458,25 @@ do_reboot() {
 }
 
 # 1:main:2
-#
+# [KIND]
 # Delete the pods and SFC (if any) and redeploy them from scratch.  As we
 # manually adjust the running pods for the demo, we need to redeploy after a
 # pod gets deleted or restarted.
 #
 # Consider running `remote redeploy`, if you didn't setup your system
 # according to "Setup localhost".
+#
+# KIND can be "auto", "ipu" or "marvell" to deploy on the respective host.
 do_redeploy() {
-    _echo_p "Redeploy nginx and resnet"
+    local kind="$1"
+    shift || :
+    local oc_kind
+
+    oc_kind="$(_detect_kind "$kind")" || die "Cannot detect kind: $oc_kind"
+
+    [ "$#" -eq 0 ] || die "invalid arguments"
+
+    _echo_p "Redeploy nginx and resnet for $oc_kind"
 
     (
         # shellcheck disable=SC2031
@@ -1475,6 +1610,8 @@ do_etc_hosts() {
     local content
     local update=0
 
+    check_no_external_cluster
+
     [ "$#" -le 1 ] || die "invalid arguments"
     if [ "$#" -ge 1 ] ; then
         case "$1" in
@@ -1603,6 +1740,8 @@ do_kubeconfigs() {
     local dir="${1:-$ORIGINAL_PWD}"
     local pwd0="$PWD"
 
+    check_no_external_cluster
+
     cd "$ORIGINAL_PWD"
 
     dir="$(realpath -s "$dir")"
@@ -1614,10 +1753,12 @@ do_kubeconfigs() {
     [ "$#" -eq 0 ] || die "Invalid arguments"
 
     do_kubeconfig_ocp > "$dir/kubeconfig.ocpcluster"
-    do_kubeconfig_microshift_ipu > "$dir/kubeconfig.microshift-ipu"
+    _kubeconfig_microshift 'ipu' > "$dir/kubeconfig.microshift-ipu"
+    _kubeconfig_microshift 'mvl' > "$dir/kubeconfig.microshift-mvl"
 
     _echo "export KC_OCP=$(printf '%q' "$dir/kubeconfig.ocpcluster")"
     _echo "export KC_IPU=$(printf '%q' "$dir/kubeconfig.microshift-ipu")"
+    _echo "export KC_MVL=$(printf '%q' "$dir/kubeconfig.microshift-mvl")"
 
     cd "$pwd0"
 }
@@ -1631,28 +1772,62 @@ do_kubeconfig_ocp() {
     _exec tgen1 cat /root/kubeconfig.ocpcluster
 }
 
-# 3:extra helper:7
-#
-# Show the kubeconfig for the IPU on dh4.
-do_kubeconfig_microshift_ipu() {
-    local hh
+_kubeconfig_microshift() {
+    local kind="$1"
+    local host
+    local external_ip
 
-    if is_prov_host ; then
-        hh="$HOST_DPU_IPU"
-    else
-        # if we are on localhost, we want that the kubeconfig can directly access
-        # the microshift instance. We thus use the external facing IP address.
-        hh="$HOST_DPU_IPU_EXTERN"
-    fi
+    case "$kind" in
+        "ipu")
+            if is_prov_host ; then
+                external_ip="$HOST_DPU_IPU"
+            else
+                # if we are on localhost, we want that the kubeconfig can directly access
+                # the microshift instance. We thus use the external facing IP address.
+                external_ip="$HOST_DPU_IPU_EXTERN"
+            fi
+            host='dh4-acc'
+            ;;
+        "mvl")
+            if is_prov_host ; then
+                external_ip="$HOST_DPU_MVL"
+            else
+                external_ip="$HOST_DPU_MVL_EXTERN"
+            fi
+            host="dh3-acc"
+            ;;
+    esac
 
     _EXEC_NOTTY=1 \
     _EXEC_SILENT=1 \
-    _exec dh4-acc cat /var/lib/microshift/resources/kubeadmin/kubeconfig \
-        | sed -e 's/^\( *\)\(certificate-authority-data: .*\)$/\1#\2\n\1insecure-skip-tls-verify: true/' \
-              -e 's#server: https://localhost:6443#server: https://'"$hh"':6443#'
+    _exec "$host" \
+        cat /var/lib/microshift/resources/kubeadmin/kubeconfig \
+        |   if [ "$EXTERNAL_CLUSTER" = 1 ] ; then
+                # from the external cluster, there is anyway no known public IP address. The user can
+                # download the kubeconfig, but they will have to adjust the server line to what works
+                # for them.
+                cat
+            else
+                sed -e 's/^\( *\)\(certificate-authority-data: .*\)$/\1#\2\n\1insecure-skip-tls-verify: true/' \
+                    -e 's#server: https://localhost:6443#server: https://'"$external_ip"':6443#'
+            fi
+}
+
+# 3:extra helper:7
+#
+# Show the kubeconfig for microshift on the IPU on dh4.
+do_kubeconfig_microshift_ipu() {
+    _kubeconfig_microshift "ipu"
 }
 
 # 3:extra helper:8
+#
+# Show the kubeconfig for microshift on the Marvell DPU on dh3.
+do_kubeconfig_microshift_mvl() {
+    _kubeconfig_microshift "mvl"
+}
+
+# 3:extra helper:9
 #
 # Run shellcheck, black and mypy on the sources of the demo script.
 do_check() {
@@ -1678,32 +1853,32 @@ do_check() {
 }
 
 _main() {
-    local cmd="$1"
+    local main_cmd="$1"
     shift || true
 
     # For convenience, accept the following aliases:
-    case "$cmd" in
+    case "$main_cmd" in
         'predict_images'|predict_images/)
-            cmd='predict'
+            main_cmd='predict'
             ;;
         'inspect.sh')
-            cmd='inspect'
+            main_cmd='inspect'
             ;;
     esac
 
-    case "$cmd" in
+    case "$main_cmd" in
         check | \
         info | \
         kubeadmin | \
         kubeconfig_microshift_ipu | \
+        kubeconfig_microshift_mvl | \
         kubeconfig_ocp | \
         nginx_setup | \
         predict | \
-        redeploy | \
         tls_generate_keys \
         )
             [ "$#" -eq 0 ] || die "Invalid arguments"
-            "do_$cmd"
+            "do_$main_cmd"
             ;;
         etc_hosts | \
         exec | \
@@ -1712,17 +1887,19 @@ _main() {
         pod_detect_net1_ip | \
         pods_setup | \
         reboot | \
+        redeploy | \
         remote | \
         ssh_copy_id | \
         tcpdump_dh4 | \
         tcpdump_pod \
         )
-            "do_$cmd" "$@"
+            "do_$main_cmd" "$@"
             ;;
         oc_ipu | \
+        oc_mvl | \
         oc_ocp \
         )
-            "$cmd" "$@"
+            "$main_cmd" "$@"
             ;;
         "-h"|"--help")
             usage
@@ -1733,7 +1910,7 @@ _main() {
             ;;
         *)
             usage
-            die "Unknown command '$cmd'"
+            die "Unknown command '$main_cmd'"
             ;;
     esac
 }

--- a/demos/Secure-AI-inferencing-NGINX-IPU/demo/inspect.sh
+++ b/demos/Secure-AI-inferencing-NGINX-IPU/demo/inspect.sh
@@ -16,11 +16,11 @@ pane0_commands=(
   "./demo.sh exec dh4-acc cat /etc/os-release"
   "./demo.sh exec dh4-acc ifconfig enp0s1f0d1"
   "./demo.sh exec dh4-imc cat /etc/issue"
-  "./demo.sh oc_msh get nodes -o wide ; sleep 3; ./demo.sh oc_msh get pods -A"
+  "./demo.sh oc_ipu get nodes -o wide ; sleep 3; ./demo.sh oc_ipu get pods -A"
   "./demo.sh oc_ocp get nodes -o wide ; sleep 3; ./demo.sh oc_ocp get pods -n default"
-  "export pod=\$(./demo.sh oc_msh get pods -A -o name | grep 'vsp-p4' | head -n1); echo \"podname: \$pod\""
-  "./demo.sh oc_msh exec -it \$pod -n openshift-dpu-operator -- /opt/p4/p4-cp-nws/bin/ovs-vsctl show"
-  "./demo.sh oc_msh exec -it \$pod -n openshift-dpu-operator -- /opt/p4/p4-cp-nws/bin/p4rt-ctl dump-entries br0 | tail -n 25"
+  "export pod=\$(./demo.sh oc_ipu get pods -A -o name | grep 'vsp-p4' | head -n1); echo \"podname: \$pod\""
+  "./demo.sh oc_ipu exec -it \$pod -n openshift-dpu-operator -- /opt/p4/p4-cp-nws/bin/ovs-vsctl show"
+  "./demo.sh oc_ipu exec -it \$pod -n openshift-dpu-operator -- /opt/p4/p4-cp-nws/bin/p4rt-ctl dump-entries br0 | tail -n 25"
 )
 pane0_comments=(
   "Redhat OS running on Intel IPU Compuete Complex (ACC)"
@@ -35,10 +35,10 @@ pane0_comments=(
 
 pane1_commands=(
   #"./demo.sh nginx_setup"
-  "./demo.sh oc_msh exec -n openshift-dpu-operator -it nginx -- ifconfig"
-  "./demo.sh oc_msh exec -n openshift-dpu-operator -it nginx -- bash -c 'grep -R ^ /etc/nginx/*.conf /etc/nginx/conf.d/*.conf'"
-  #"nowait:./demo.sh oc_msh exec -n openshift-dpu-operator -it nginx -- tcpdump -ni net2"
-  "nowait:./demo.sh oc_msh logs -n openshift-dpu-operator --follow nginx"
+  "./demo.sh oc_ipu exec -n openshift-dpu-operator -it nginx -- ifconfig"
+  "./demo.sh oc_ipu exec -n openshift-dpu-operator -it nginx -- bash -c 'grep -R ^ /etc/nginx/*.conf /etc/nginx/conf.d/*.conf'"
+  #"nowait:./demo.sh oc_ipu exec -n openshift-dpu-operator -it nginx -- tcpdump -ni net2"
+  "nowait:./demo.sh oc_ipu logs -n openshift-dpu-operator --follow nginx"
 )
 pane1_comments=(
   #"Bring In NGINX Server Configuration Running at Microshift Cluster on Intel IPU"

--- a/demos/Secure-AI-inferencing-NGINX-IPU/demo/inspect.sh
+++ b/demos/Secure-AI-inferencing-NGINX-IPU/demo/inspect.sh
@@ -90,7 +90,7 @@ pane0_client_comments=(
 
 pane_nginx_status_commands=(
    #"nowait:watch -n1 ./demo.sh remote exec tgen1 curl -s --cacert /tmp/opilab-demo/server.crt https://172.16.3.200/nginx_status"
-   "nowait:bash -c 'source ./demo.sh ; _cmd_ipu_statistics 1'"
+   "nowait:bash -c 'source ./demo.sh ; oc_kind=ipu ; _cmd_ipu_statistics 1'"
 )
 pane_nginx_status_comments=(
   #"Offloaded NGINX Proxy Server Realtime Stats - Running On Intel IPU (SmartNIC)"


### PR DESCRIPTION
We want that our demo.sh script supports multiple (partly conflicting) things:

Previously, the opilab only supported the two cluster design with one DPU. That is, we have an OCP cluster with one worker node for the IPU. And on the IPU we run a separate microshift cluster.

In a next step, we will want to add a Marvell DPU to that cluster. So the OCP cluster will have two worker nodes, with an IPU and Marvell DPU respectively. This is still a two-cluster design (where we have Microshift on the DPU). Anyway, this is a major feature for the demo, because we want to show that different vendors can be used the same way. The script needs adjustment for that, and the main point of this branch is to move in that direction.

Later, we may want to switch to a single cluster design, where there is only one OCP cluster and the DPUs also are worker nodes (with Red Hat CoreOS running). This is just something to keep in mind and something we will want to change the demo script to. The code currently does not work that way.

Also, we have other clusters with similar setups. It will be very useful to use the `./demo.sh redeploy|predict` steps to create and test the same demo setup. This is also a goal of this branch, to make that possible. In that case, the caller will setup some environment variables to tweak the script so it works (in parts!) outside the OPI lab. The alternative would be to create an outside fork of the demo.sh script, but that seems undesirable.

The downside is of course that the script can do more and gets more complicated. Optimally, a reviewer can read the script and understand what is being done. Simplicity conflicts with that goal. I hope this still finds a useful balance between being understandable and being useful.